### PR TITLE
v0.0.13 Support custom memory allocation and free logic via callbacks (add KlogAllocInfo)

### DIFF
--- a/cmake/KlogVersion.cmake
+++ b/cmake/KlogVersion.cmake
@@ -16,4 +16,5 @@ endfunction()
 # set_klog_versions(0 0 9) # klog_logger_set_level -> klog_logger_level_set
 # set_klog_versions(0 0 10) # Formatting
 # set_klog_versions(0 0 11) # EOF Newlines
-set_klog_versions(0 0 12) # Pre-allocate message buffer, don't malloc for message formatting
+# set_klog_versions(0 0 12) # Pre-allocate message buffer, don't malloc for message formatting
+set_klog_versions(0 0 13) # Allow users to specify callbacks for custom allocation and free logic

--- a/include/klog/klog.h
+++ b/include/klog/klog.h
@@ -2,6 +2,7 @@
 #define KLOG_INCLUDED
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #define KLOG_EXIT_CODE 32
@@ -44,6 +45,18 @@ typedef struct {
 } KlogFileInfo;
 
 /**
+ * @brief User provided callbacks for custom allocation and free logic
+ */
+typedef struct {
+    void* (*cb_alloc)(
+        size_t size
+    );
+    void (*cb_free)(
+        void*
+    );
+} KlogAllocInfo;
+
+/**
  * @enum KlogLevel The different levels of verbosity
  */
 enum KlogLevel {
@@ -61,7 +74,8 @@ void klog_initialize(
     const KlogFormatInfo   klog_format_info,
     const KlogAsyncInfo*   p_klog_async_info,
     const KlogConsoleInfo* p_klog_console_info,
-    const KlogFileInfo*    p_klog_file_info
+    const KlogFileInfo*    p_klog_file_info,
+    const KlogAllocInfo*   p_klog_alloc_info
 );
 
 void klog_deinitialize(

--- a/include/klog/klog.h
+++ b/include/klog/klog.h
@@ -48,10 +48,10 @@ typedef struct {
  * @brief User provided callbacks for custom allocation and free logic
  */
 typedef struct {
-    void* (*cb_alloc)(
+    void* (*alloc_cb)(
         size_t size
     );
-    void (*cb_free)(
+    void (*free_cb)(
         void*
     );
 } KlogAllocInfo;

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -65,7 +65,7 @@ for test_command in "${all_tests_to_run[@]}"; do
     command_to_run="$test_command"
 
     if [[ ! " ${ignore_memory_list[*]} " =~ " ${test_name} " ]]; then
-        command_to_run="valgrind --tool=memcheck --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=all --error-exitcode=54 $command_to_run"
+        command_to_run="valgrind --tool=memcheck --enable-debuginfod=no --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=all --error-exitcode=54 $command_to_run"
     fi
 
     $command_to_run > /dev/null 2>&1

--- a/src/klog/CMakeLists.txt
+++ b/src/klog/CMakeLists.txt
@@ -28,6 +28,7 @@ target_compile_options(klog PUBLIC ${KLOG_CMAKE_C_FLAGS})
 target_compile_definitions(klog PUBLIC ${KLOG_COMPILE_DEFINITIONS})
 
 if (KLOG_BUILD_TESTS)
+    create_unit_test_plain(ut/ut-klog_alloc_callback_counts.c klog)
     create_unit_test_plain(ut/ut-klog_deinitialize.c klog)
     create_unit_test_plain(ut/ut-klog_format_input_message.c klog)
     create_unit_test_plain(ut/ut-klog_format_logger_name.c klog)

--- a/src/klog/ft/ft-klog_basic.c
+++ b/src/klog/ft/ft-klog_basic.c
@@ -17,7 +17,7 @@ int main(
     KlogConsoleInfo console_info = { KLOG_LEVEL_DEBUG, true };
     KlogFileInfo    file_info    = { KLOG_LEVEL_INFO, "BASIC\tPREFIX" };
     kdprintf("INITIALIZING KLOG\n");
-    klog_initialize(4, format_info, NULL, &console_info, &file_info);
+    klog_initialize(4, format_info, NULL, &console_info, &file_info, NULL);
 
     kdprintf("CREATING HANDLE\n");
     const KlogLoggerHandle* handle_1 = klog_logger_create("My Logger");

--- a/src/klog/ft/ft-klog_console.c
+++ b/src/klog/ft/ft-klog_console.c
@@ -13,7 +13,7 @@ void do_it(
 ) {
     KlogFormatInfo  format_info = { 4, 10, 5, true, false };
     KlogConsoleInfo stdout_info = { KLOG_LEVEL_TRACE, use_color };
-    klog_initialize(2, format_info, NULL, &stdout_info, NULL);
+    klog_initialize(2, format_info, NULL, &stdout_info, NULL, NULL);
 
     const KlogLoggerHandle* handle_1 = klog_logger_create("Logger");
     klog_logger_level_set(handle_1, KLOG_LEVEL_TRACE);

--- a/src/klog/ft/ft-klog_fail_level.c
+++ b/src/klog/ft/ft-klog_fail_level.c
@@ -9,7 +9,7 @@
 int main(
     void
 ) {
-    klog_initialize(1, (KlogFormatInfo) { 10, 5, 0, false, false }, NULL, NULL, NULL);
+    klog_initialize(1, (KlogFormatInfo) { 10, 5, 0, false, false }, NULL, NULL, NULL, NULL);
 
     const KlogLoggerHandle* p_handle = klog_logger_create("ABCDE");
 

--- a/src/klog/ft/ft-klog_fail_logger_limit.c
+++ b/src/klog/ft/ft-klog_fail_logger_limit.c
@@ -13,7 +13,7 @@ int main(
     void
 ) {
     KlogFormatInfo format_info = { 6, 100, 20, true, false };
-    klog_initialize(2, format_info, NULL, NULL, NULL);
+    klog_initialize(2, format_info, NULL, NULL, NULL, NULL);
 
     const KlogLoggerHandle* handle_1 = klog_logger_create("MyLogger");
     klog(handle_1, KLOG_LEVEL_INFO, "This should not appear");

--- a/src/klog/ft/ft-klog_file.c
+++ b/src/klog/ft/ft-klog_file.c
@@ -15,7 +15,7 @@ int main(
 ) {
     KlogFormatInfo format_info = { 8, 10, 0, true, true };
     KlogFileInfo   file_info   = { KLOG_LEVEL_INFO, "FILE__PREFIX____OR_WHATEVER_THIS_PREFIX_IS_LONG" };
-    klog_initialize(4, format_info, NULL, NULL, &file_info);
+    klog_initialize(4, format_info, NULL, NULL, &file_info, NULL);
 
     const KlogLoggerHandle* handle_1 = klog_logger_create("MyLogger");
     klog_logger_level_set(handle_1, KLOG_LEVEL_DEBUG);

--- a/src/klog/ft/ft-klog_stress_st_sync.c
+++ b/src/klog/ft/ft-klog_stress_st_sync.c
@@ -14,7 +14,14 @@
 void do_test(
     void
 ) {
-    klog_initialize(NUM_LOGGERS, (KlogFormatInfo) { 3, 40, 10, false, false }, NULL, &(KlogConsoleInfo) { KLOG_LEVEL_TRACE, false }, NULL);
+    klog_initialize(
+        NUM_LOGGERS,
+        (KlogFormatInfo) { 3, 40, 10, false, false },
+        NULL,
+        &(KlogConsoleInfo) { KLOG_LEVEL_TRACE, false },
+        NULL,
+        NULL
+    );
 
     const KlogLoggerHandle* a_handles[NUM_LOGGERS];
     for (uint32_t i = 0; i < NUM_LOGGERS; ++i) {

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -262,7 +262,7 @@ const KlogLoggerHandle* klog_logger_create(
         ? g_klog_config.format.logger_name_max_length /* copy as much as we can fit */
         : strlen(s_sanitized_name); /* copy it all - NOT including the null terminator (which strlen doesn't count anyways) */
     memcpy(&g_klog_state.b_logger_names[logger_name_start_index], s_sanitized_name, number_chars_to_copy);
-    free((char*)s_sanitized_name);
+    g_klog_config.alloc.cb_free((char*)s_sanitized_name);
 
     g_klog_state.a_logger_levels[current_logger_index] = KLOG_LEVEL_OFF;
 

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -21,7 +21,8 @@ void klog_initialize(
     const KlogFormatInfo         klog_format_info,
     const KlogAsyncInfo* const   p_klog_async_info,
     const KlogConsoleInfo* const p_klog_console_info,
-    const KlogFileInfo* const    p_klog_file_info
+    const KlogFileInfo* const    p_klog_file_info,
+    const KlogAllocInfo* const   p_klog_alloc_info
 ) {
 #ifdef KLOG_OFF
     (void)max_number_loggers;
@@ -29,6 +30,7 @@ void klog_initialize(
     (void)p_klog_async_info;
     (void)p_klog_console_info;
     (void)p_klog_file_info;
+    (void)p_klog_alloc_info;
 #else
     if (
         !klog_initialize_are_parameters_valid(
@@ -37,7 +39,8 @@ void klog_initialize(
             klog_format_info,
             p_klog_async_info,
             p_klog_console_info,
-            p_klog_file_info
+            p_klog_file_info,
+            p_klog_alloc_info
         )
     ) {
         exit(KLOG_EXIT_CODE);
@@ -53,6 +56,12 @@ void klog_initialize(
     if (p_klog_file_info) {
         g_klog_config.file = *p_klog_file_info;
     }
+    if (p_klog_alloc_info) {
+        g_klog_config.alloc = *p_klog_alloc_info;
+    } else {
+        g_klog_config.alloc.cb_alloc = &malloc;
+        g_klog_config.alloc.cb_free  = &free;
+    }
 
     g_klog_state.number_loggers_max = max_number_loggers;
 
@@ -60,7 +69,8 @@ void klog_initialize(
         g_klog_state.number_loggers_max,
         g_klog_config.format.logger_name_max_length,
         ' ',
-        false
+        false,
+        g_klog_config.alloc.cb_alloc
     );
     kdprintf(
         "b_logger_names: %p through %p\n",
@@ -68,21 +78,21 @@ void klog_initialize(
         (void*)(g_klog_state.b_logger_names + (max_number_loggers * klog_format_info.logger_name_max_length))
     );
 
-    g_klog_state.a_logger_levels = klog_initialize_logger_levels_array(g_klog_state.number_loggers_max);
+    g_klog_state.a_logger_levels = klog_initialize_logger_levels_array(g_klog_state.number_loggers_max, g_klog_config.alloc.cb_alloc);
     kdprintf(
         "a_logger_levels: %p through %p\n",
         (void*)g_klog_state.a_logger_levels,
         (void*)(g_klog_state.a_logger_levels + g_klog_state.number_loggers_max)
     );
 
-    g_klog_state.b_level_strings = klog_initialize_level_strings_buffer();
+    g_klog_state.b_level_strings = klog_initialize_level_strings_buffer(g_klog_config.alloc.cb_alloc);
     kdprintf(
         "b_level_strings: %p through %p\n",
         (void*)g_klog_state.b_level_strings,
         (void*)(g_klog_state.b_level_strings + (G_klog_level_string_length * G_klog_number_levels))
     );
 
-    g_klog_state.b_level_strings_colored = klog_initialize_colored_level_strings_buffer();
+    g_klog_state.b_level_strings_colored = klog_initialize_colored_level_strings_buffer(g_klog_config.alloc.cb_alloc);
     kdprintf(
         "b_level_strings_colored: %p through %p\n",
         (void*)g_klog_state.b_level_strings_colored,
@@ -91,7 +101,7 @@ void klog_initialize(
 
     g_klog_state.number_loggers_created = 0;
 
-    g_klog_state.a_logger_handles = klog_initialize_logger_handle_array(g_klog_state.number_loggers_max);
+    g_klog_state.a_logger_handles = klog_initialize_logger_handle_array(g_klog_state.number_loggers_max, g_klog_config.alloc.cb_alloc);
     kdprintf(
         "a_logger_handles: %p through %p\n",
         (void*)g_klog_state.a_logger_handles,
@@ -124,25 +134,29 @@ void klog_initialize(
         g_klog_state.prefix_element_count,
         g_klog_state.prefix_file_size,
         '\0',
-        true
+        true,
+        g_klog_config.alloc.cb_alloc
     );
     g_klog_state.b_prefixes_console = klog_initialize_buffer(
         g_klog_state.prefix_element_count,
         g_klog_state.prefix_console_size,
         '\0',
-        true
+        true,
+        g_klog_config.alloc.cb_alloc
     );
     g_klog_state.b_prefixes_time = klog_initialize_buffer(
         g_klog_state.prefix_element_count,
         g_klog_state.prefix_time_size,
         '$',
-        true
+        true,
+        g_klog_config.alloc.cb_alloc
     );
     g_klog_state.b_prefixes_source_location = klog_initialize_buffer(
         g_klog_state.prefix_element_count,
         g_klog_state.prefix_source_location_size,
         '@',
-        true
+        true,
+        g_klog_config.alloc.cb_alloc
     );
 
     g_klog_state.message_formatted_max_size = g_klog_config.format.message_max_length;
@@ -150,10 +164,11 @@ void klog_initialize(
         1,
         g_klog_state.message_formatted_max_size,
         '\0',
-        true
+        true,
+        g_klog_config.alloc.cb_alloc
     );
 
-    g_klog_state.p_file = klog_initialize_file(p_klog_file_info);
+    g_klog_state.p_file = klog_initialize_file(p_klog_file_info, g_klog_config.alloc.cb_alloc);
     kdprintf("p_file: %p\n",             (void*)g_klog_state.p_file);
     kdprintf("File max verbosity: %d\n", g_klog_config.file.max_level);
 
@@ -171,20 +186,18 @@ void klog_deinitialize(
         exit(KLOG_EXIT_CODE);
     }
 
-    g_klog_config = (struct KlogConfig) { 0 };
-
     g_klog_state.number_loggers_max     = 0;
     g_klog_state.number_loggers_created = 0;
 
-    free(g_klog_state.a_logger_handles);
-    free(g_klog_state.b_logger_names);
-    free(g_klog_state.a_logger_levels);
+    g_klog_config.alloc.cb_free(g_klog_state.a_logger_handles);
+    g_klog_config.alloc.cb_free(g_klog_state.b_logger_names);
+    g_klog_config.alloc.cb_free(g_klog_state.a_logger_levels);
     g_klog_state.a_logger_handles = NULL;
     g_klog_state.b_logger_names   = NULL;
     g_klog_state.a_logger_levels  = NULL;
 
-    free(g_klog_state.b_level_strings);
-    free(g_klog_state.b_level_strings_colored);
+    g_klog_config.alloc.cb_free(g_klog_state.b_level_strings);
+    g_klog_config.alloc.cb_free(g_klog_state.b_level_strings_colored);
     g_klog_state.b_level_strings         = NULL;
     g_klog_state.b_level_strings_colored = NULL;
 
@@ -192,29 +205,32 @@ void klog_deinitialize(
     g_klog_state.prefix_element_count = 0;
 
     g_klog_state.prefix_file_size = 0;
-    free(g_klog_state.b_prefixes_file);
+    g_klog_config.alloc.cb_free(g_klog_state.b_prefixes_file);
     g_klog_state.b_prefixes_file = NULL;
 
     g_klog_state.prefix_console_size = 0;
-    free(g_klog_state.b_prefixes_console);
+    g_klog_config.alloc.cb_free(g_klog_state.b_prefixes_console);
     g_klog_state.b_prefixes_console = NULL;
 
     g_klog_state.prefix_time_size = 0;
-    free(g_klog_state.b_prefixes_time);
+    g_klog_config.alloc.cb_free(g_klog_state.b_prefixes_time);
     g_klog_state.b_prefixes_time = NULL;
 
     g_klog_state.prefix_source_location_size = 0;
-    free(g_klog_state.b_prefixes_source_location);
+    g_klog_config.alloc.cb_free(g_klog_state.b_prefixes_source_location);
     g_klog_state.b_prefixes_source_location = NULL;
 
     g_klog_state.message_formatted_max_size = 0;
-    free(g_klog_state.b_message_formatted);
+    g_klog_config.alloc.cb_free(g_klog_state.b_message_formatted);
     g_klog_state.b_message_formatted = NULL;
 
     if (g_klog_state.p_file) {
         fclose(g_klog_state.p_file);
         g_klog_state.p_file = NULL;
     }
+
+    /* Need to do this near the end because we need the callbacks for freeing */
+    g_klog_config = (struct KlogConfig) { 0 };
 
     g_klog_state.is_initialized = false;
 #endif
@@ -239,7 +255,7 @@ const KlogLoggerHandle* klog_logger_create(
 
     const uint32_t current_logger_index = g_klog_state.number_loggers_created;
 
-    const char* const s_sanitized_name = klog_format_logger_name(s_logger_name);
+    const char* const s_sanitized_name = klog_format_logger_name(s_logger_name, g_klog_config.alloc.cb_alloc);
 
     const uint32_t logger_name_start_index = current_logger_index * g_klog_config.format.logger_name_max_length;
     const uint32_t number_chars_to_copy    = strlen(s_sanitized_name) >= g_klog_config.format.logger_name_max_length

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -59,8 +59,8 @@ void klog_initialize(
     if (p_klog_alloc_info) {
         g_klog_config.alloc = *p_klog_alloc_info;
     } else {
-        g_klog_config.alloc.cb_alloc = &malloc;
-        g_klog_config.alloc.cb_free  = &free;
+        g_klog_config.alloc.alloc_cb = &malloc;
+        g_klog_config.alloc.free_cb  = &free;
     }
 
     g_klog_state.number_loggers_max = max_number_loggers;
@@ -70,7 +70,7 @@ void klog_initialize(
         g_klog_config.format.logger_name_max_length,
         ' ',
         false,
-        g_klog_config.alloc.cb_alloc
+        g_klog_config.alloc.alloc_cb
     );
     kdprintf(
         "b_logger_names: %p through %p\n",
@@ -78,21 +78,21 @@ void klog_initialize(
         (void*)(g_klog_state.b_logger_names + (max_number_loggers * klog_format_info.logger_name_max_length))
     );
 
-    g_klog_state.a_logger_levels = klog_initialize_logger_levels_array(g_klog_state.number_loggers_max, g_klog_config.alloc.cb_alloc);
+    g_klog_state.a_logger_levels = klog_initialize_logger_levels_array(g_klog_state.number_loggers_max, g_klog_config.alloc.alloc_cb);
     kdprintf(
         "a_logger_levels: %p through %p\n",
         (void*)g_klog_state.a_logger_levels,
         (void*)(g_klog_state.a_logger_levels + g_klog_state.number_loggers_max)
     );
 
-    g_klog_state.b_level_strings = klog_initialize_level_strings_buffer(g_klog_config.alloc.cb_alloc);
+    g_klog_state.b_level_strings = klog_initialize_level_strings_buffer(g_klog_config.alloc.alloc_cb);
     kdprintf(
         "b_level_strings: %p through %p\n",
         (void*)g_klog_state.b_level_strings,
         (void*)(g_klog_state.b_level_strings + (G_klog_level_string_length * G_klog_number_levels))
     );
 
-    g_klog_state.b_level_strings_colored = klog_initialize_colored_level_strings_buffer(g_klog_config.alloc.cb_alloc);
+    g_klog_state.b_level_strings_colored = klog_initialize_colored_level_strings_buffer(g_klog_config.alloc.alloc_cb);
     kdprintf(
         "b_level_strings_colored: %p through %p\n",
         (void*)g_klog_state.b_level_strings_colored,
@@ -101,7 +101,7 @@ void klog_initialize(
 
     g_klog_state.number_loggers_created = 0;
 
-    g_klog_state.a_logger_handles = klog_initialize_logger_handle_array(g_klog_state.number_loggers_max, g_klog_config.alloc.cb_alloc);
+    g_klog_state.a_logger_handles = klog_initialize_logger_handle_array(g_klog_state.number_loggers_max, g_klog_config.alloc.alloc_cb);
     kdprintf(
         "a_logger_handles: %p through %p\n",
         (void*)g_klog_state.a_logger_handles,
@@ -135,28 +135,28 @@ void klog_initialize(
         g_klog_state.prefix_file_size,
         '\0',
         true,
-        g_klog_config.alloc.cb_alloc
+        g_klog_config.alloc.alloc_cb
     );
     g_klog_state.b_prefixes_console = klog_initialize_buffer(
         g_klog_state.prefix_element_count,
         g_klog_state.prefix_console_size,
         '\0',
         true,
-        g_klog_config.alloc.cb_alloc
+        g_klog_config.alloc.alloc_cb
     );
     g_klog_state.b_prefixes_time = klog_initialize_buffer(
         g_klog_state.prefix_element_count,
         g_klog_state.prefix_time_size,
         '$',
         true,
-        g_klog_config.alloc.cb_alloc
+        g_klog_config.alloc.alloc_cb
     );
     g_klog_state.b_prefixes_source_location = klog_initialize_buffer(
         g_klog_state.prefix_element_count,
         g_klog_state.prefix_source_location_size,
         '@',
         true,
-        g_klog_config.alloc.cb_alloc
+        g_klog_config.alloc.alloc_cb
     );
 
     g_klog_state.message_formatted_max_size = g_klog_config.format.message_max_length;
@@ -165,10 +165,10 @@ void klog_initialize(
         g_klog_state.message_formatted_max_size,
         '\0',
         true,
-        g_klog_config.alloc.cb_alloc
+        g_klog_config.alloc.alloc_cb
     );
 
-    g_klog_state.p_file = klog_initialize_file(p_klog_file_info, g_klog_config.alloc.cb_alloc);
+    g_klog_state.p_file = klog_initialize_file(p_klog_file_info, g_klog_config.alloc.alloc_cb);
     kdprintf("p_file: %p\n",             (void*)g_klog_state.p_file);
     kdprintf("File max verbosity: %d\n", g_klog_config.file.max_level);
 
@@ -189,15 +189,15 @@ void klog_deinitialize(
     g_klog_state.number_loggers_max     = 0;
     g_klog_state.number_loggers_created = 0;
 
-    g_klog_config.alloc.cb_free(g_klog_state.a_logger_handles);
-    g_klog_config.alloc.cb_free(g_klog_state.b_logger_names);
-    g_klog_config.alloc.cb_free(g_klog_state.a_logger_levels);
+    g_klog_config.alloc.free_cb(g_klog_state.a_logger_handles);
+    g_klog_config.alloc.free_cb(g_klog_state.b_logger_names);
+    g_klog_config.alloc.free_cb(g_klog_state.a_logger_levels);
     g_klog_state.a_logger_handles = NULL;
     g_klog_state.b_logger_names   = NULL;
     g_klog_state.a_logger_levels  = NULL;
 
-    g_klog_config.alloc.cb_free(g_klog_state.b_level_strings);
-    g_klog_config.alloc.cb_free(g_klog_state.b_level_strings_colored);
+    g_klog_config.alloc.free_cb(g_klog_state.b_level_strings);
+    g_klog_config.alloc.free_cb(g_klog_state.b_level_strings_colored);
     g_klog_state.b_level_strings         = NULL;
     g_klog_state.b_level_strings_colored = NULL;
 
@@ -205,23 +205,23 @@ void klog_deinitialize(
     g_klog_state.prefix_element_count = 0;
 
     g_klog_state.prefix_file_size = 0;
-    g_klog_config.alloc.cb_free(g_klog_state.b_prefixes_file);
+    g_klog_config.alloc.free_cb(g_klog_state.b_prefixes_file);
     g_klog_state.b_prefixes_file = NULL;
 
     g_klog_state.prefix_console_size = 0;
-    g_klog_config.alloc.cb_free(g_klog_state.b_prefixes_console);
+    g_klog_config.alloc.free_cb(g_klog_state.b_prefixes_console);
     g_klog_state.b_prefixes_console = NULL;
 
     g_klog_state.prefix_time_size = 0;
-    g_klog_config.alloc.cb_free(g_klog_state.b_prefixes_time);
+    g_klog_config.alloc.free_cb(g_klog_state.b_prefixes_time);
     g_klog_state.b_prefixes_time = NULL;
 
     g_klog_state.prefix_source_location_size = 0;
-    g_klog_config.alloc.cb_free(g_klog_state.b_prefixes_source_location);
+    g_klog_config.alloc.free_cb(g_klog_state.b_prefixes_source_location);
     g_klog_state.b_prefixes_source_location = NULL;
 
     g_klog_state.message_formatted_max_size = 0;
-    g_klog_config.alloc.cb_free(g_klog_state.b_message_formatted);
+    g_klog_config.alloc.free_cb(g_klog_state.b_message_formatted);
     g_klog_state.b_message_formatted = NULL;
 
     if (g_klog_state.p_file) {
@@ -255,14 +255,14 @@ const KlogLoggerHandle* klog_logger_create(
 
     const uint32_t current_logger_index = g_klog_state.number_loggers_created;
 
-    const char* const s_sanitized_name = klog_format_logger_name(s_logger_name, g_klog_config.alloc.cb_alloc);
+    const char* const s_sanitized_name = klog_format_logger_name(s_logger_name, g_klog_config.alloc.alloc_cb);
 
     const uint32_t logger_name_start_index = current_logger_index * g_klog_config.format.logger_name_max_length;
     const uint32_t number_chars_to_copy    = strlen(s_sanitized_name) >= g_klog_config.format.logger_name_max_length
         ? g_klog_config.format.logger_name_max_length /* copy as much as we can fit */
         : strlen(s_sanitized_name); /* copy it all - NOT including the null terminator (which strlen doesn't count anyways) */
     memcpy(&g_klog_state.b_logger_names[logger_name_start_index], s_sanitized_name, number_chars_to_copy);
-    g_klog_config.alloc.cb_free((char*)s_sanitized_name);
+    g_klog_config.alloc.free_cb((char*)s_sanitized_name);
 
     g_klog_state.a_logger_levels[current_logger_index] = KLOG_LEVEL_OFF;
 

--- a/src/klog/klog_format.c
+++ b/src/klog/klog_format.c
@@ -42,7 +42,7 @@ uint32_t klog_format_prefix_length_get(
 
 const char* klog_format_logger_name(
     const char* const s_name,
-    void* (* const    cb_alloc)(
+    void* (* const    alloc_cb)(
         size_t size
     )
 ) {
@@ -52,7 +52,7 @@ const char* klog_format_logger_name(
      */
 
     const uint32_t length_name      = strlen(s_name);
-    char*          s_sanitized_name = cb_alloc(length_name + 1); /* +1 for null termination */
+    char*          s_sanitized_name = alloc_cb(length_name + 1); /* +1 for null termination */
 
     for (uint32_t i_input_char = 0; i_input_char < length_name; ++i_input_char) {
         const char curr_char     = s_name[i_input_char];
@@ -77,7 +77,7 @@ const char* klog_format_logger_name(
 
 const char* klog_format_file_name_prefix(
     const char* const s_name,
-    void* (* const    cb_alloc)(
+    void* (* const    alloc_cb)(
         size_t size
     )
 ) {
@@ -87,7 +87,7 @@ const char* klog_format_file_name_prefix(
 
     /* @todo kjk 2026/02/12 Should we be doing anything to sanitize filepaths for windows vs linux? Convert "/" to "\\" and vice versa?? */
 
-    return klog_format_logger_name(s_name, cb_alloc);
+    return klog_format_logger_name(s_name, alloc_cb);
 }
 
 KlogString klog_format_message_prefix(

--- a/src/klog/klog_format.c
+++ b/src/klog/klog_format.c
@@ -41,7 +41,10 @@ uint32_t klog_format_prefix_length_get(
 }
 
 const char* klog_format_logger_name(
-    const char* const s_name
+    const char* const s_name,
+    void* (* const    cb_alloc)(
+        size_t size
+    )
 ) {
     /**
      * Perhaps we should be doing this in place but creating loggers is not where we will
@@ -49,7 +52,7 @@ const char* klog_format_logger_name(
      */
 
     const uint32_t length_name      = strlen(s_name);
-    char*          s_sanitized_name = malloc(length_name + 1); /* +1 for null termination */
+    char*          s_sanitized_name = cb_alloc(length_name + 1); /* +1 for null termination */
 
     for (uint32_t i_input_char = 0; i_input_char < length_name; ++i_input_char) {
         const char curr_char     = s_name[i_input_char];
@@ -73,7 +76,10 @@ const char* klog_format_logger_name(
 }
 
 const char* klog_format_file_name_prefix(
-    const char* const s_name
+    const char* const s_name,
+    void* (* const    cb_alloc)(
+        size_t size
+    )
 ) {
     /**
      * Perhaps we should be doing this in place but creating the file only happens once so, oh well
@@ -81,7 +87,7 @@ const char* klog_format_file_name_prefix(
 
     /* @todo kjk 2026/02/12 Should we be doing anything to sanitize filepaths for windows vs linux? Convert "/" to "\\" and vice versa?? */
 
-    return klog_format_logger_name(s_name);
+    return klog_format_logger_name(s_name, cb_alloc);
 }
 
 KlogString klog_format_message_prefix(

--- a/src/klog/klog_format.h
+++ b/src/klog/klog_format.h
@@ -21,14 +21,14 @@ uint32_t klog_format_prefix_length_get(
 
 const char* klog_format_logger_name(
     const char*    s_name,
-    void* (* const cb_alloc)(
+    void* (* const alloc_cb)(
         size_t size
     )
 );
 
 const char* klog_format_file_name_prefix(
     const char*    s_name,
-    void* (* const cb_alloc)(
+    void* (* const alloc_cb)(
         size_t size
     )
 );

--- a/src/klog/klog_format.h
+++ b/src/klog/klog_format.h
@@ -3,6 +3,7 @@
 
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 typedef struct {
@@ -19,11 +20,17 @@ uint32_t klog_format_prefix_length_get(
 );
 
 const char* klog_format_logger_name(
-    const char* s_name
+    const char*    s_name,
+    void* (* const cb_alloc)(
+        size_t size
+    )
 );
 
 const char* klog_format_file_name_prefix(
-    const char* s_name
+    const char*    s_name,
+    void* (* const cb_alloc)(
+        size_t size
+    )
 );
 
 KlogString klog_format_message_prefix(

--- a/src/klog/klog_initialize.c
+++ b/src/klog/klog_initialize.c
@@ -14,11 +14,14 @@ char* klog_initialize_buffer(
     const uint32_t number_elements,
     const uint32_t element_length_max,
     const char     fill_char,
-    const bool     null_terminate
+    const bool     null_terminate,
+    void* (* const cb_alloc)(
+        size_t size
+    )
 ) {
     const uint32_t element_length_max_real = null_terminate ? element_length_max + 1 : element_length_max;
     const uint32_t total_size              = number_elements * element_length_max_real;
-    char* const    b_buffer                = malloc(total_size);
+    char* const    b_buffer                = cb_alloc(total_size);
     memset(b_buffer, fill_char, total_size);
     if (null_terminate) {
         for (uint32_t i = 0; i < number_elements; ++i) {
@@ -44,7 +47,8 @@ bool klog_initialize_are_parameters_valid(
     const KlogFormatInfo         klog_format_info,
     const KlogAsyncInfo* const   p_klog_async_info,
     const KlogConsoleInfo* const p_klog_console_info,
-    const KlogFileInfo* const    p_klog_file_info
+    const KlogFileInfo* const    p_klog_file_info,
+    const KlogAllocInfo* const   p_klog_alloc_info
 ) {
     if (klog_is_initialized) {
         kdprintf("Trying to initialize klog, when it is already initialized\n");
@@ -77,6 +81,17 @@ bool klog_initialize_are_parameters_valid(
         /* Make sure filename prefix is valid */
     }
 
+    if (p_klog_alloc_info) {
+        if (p_klog_alloc_info->cb_alloc == NULL) {
+            kdprintf("Trying to initialize klog with alloc info struct, yet the alloc callback is NULL\n");
+            return false;
+        }
+        if (p_klog_alloc_info->cb_free == NULL) {
+            kdprintf("Trying to initialize klog with alloc info struct, yet the free callback is NULL\n");
+            return false;
+        }
+    }
+
     /* @todo kjk 2026/01/21 This is currently unused */
     (void)p_klog_console_info;
 
@@ -84,10 +99,13 @@ bool klog_initialize_are_parameters_valid(
 }
 
 KlogLoggerHandle* klog_initialize_logger_handle_array(
-    const uint32_t max_number_loggers
+    const uint32_t max_number_loggers,
+    void* (* const cb_alloc)(
+        size_t size
+    )
 ) {
     const uint32_t          total_handle_array_size = max_number_loggers * sizeof(KlogLoggerHandle);
-    KlogLoggerHandle* const a_logger_handles        = malloc(total_handle_array_size);
+    KlogLoggerHandle* const a_logger_handles        = cb_alloc(total_handle_array_size);
     kdprintf("Created logger handle array\n");
     kdprintf("  start: %p\n", (void*)a_logger_handles);
     kdprintf("  end  : %p\n", (void*)(a_logger_handles + total_handle_array_size));
@@ -97,10 +115,13 @@ KlogLoggerHandle* klog_initialize_logger_handle_array(
 }
 
 uint8_t* klog_initialize_logger_levels_array(
-    const uint32_t max_number_loggers
+    const uint32_t max_number_loggers,
+    void* (* const cb_alloc)(
+        size_t size
+    )
 ) {
     const uint32_t logger_levels_array_size_bytes = max_number_loggers * sizeof(uint8_t*);
-    uint8_t* const a_logger_levels                = malloc(logger_levels_array_size_bytes);
+    uint8_t* const a_logger_levels                = cb_alloc(logger_levels_array_size_bytes);
     memset(a_logger_levels, 0, logger_levels_array_size_bytes);
 
     kdprintf("Created logger levels array\n");
@@ -112,10 +133,12 @@ uint8_t* klog_initialize_logger_levels_array(
 }
 
 char* klog_initialize_level_strings_buffer(
-    void
+    void* (*const cb_alloc)(
+        size_t size
+    )
 ) {
     const uint32_t level_string_array_total_bytes = G_klog_level_string_length * G_klog_number_levels;
-    char* const    b_level_strings                = malloc(level_string_array_total_bytes);
+    char* const    b_level_strings                = cb_alloc(level_string_array_total_bytes);
     const char     off_string[]                   = "off  ";
     const char     fatal_string[]                 = "FATAL";
     const char     error_string[]                 = "ERROR";
@@ -140,10 +163,12 @@ char* klog_initialize_level_strings_buffer(
 }
 
 char* klog_initialize_colored_level_strings_buffer(
-    void
+    void* (*const cb_alloc)(
+        size_t size
+    )
 ) {
     const uint32_t colored_level_string_array_total_bytes = G_klog_colored_level_string_length * G_klog_number_levels;
-    char* const    b_colored_level_strings                = malloc(colored_level_string_array_total_bytes);
+    char* const    b_colored_level_strings                = cb_alloc(colored_level_string_array_total_bytes);
     const char     off_string[]                           = "\x1b[37moff  \x1b[0m"; /* white  */
     const char     fatal_string[]                         = "\x1b[41mFATAL\x1b[0m"; /* red BG */
     const char     error_string[]                         = "\x1b[31mERROR\x1b[0m"; /* red    */
@@ -168,7 +193,10 @@ char* klog_initialize_colored_level_strings_buffer(
 }
 
 FILE* klog_initialize_file(
-    const KlogFileInfo* const p_klog_file_info
+    const KlogFileInfo* const p_klog_file_info,
+    void* (* const            cb_alloc)(
+        size_t size
+    )
 ) {
     if (p_klog_file_info == NULL) {
         kdprintf("Not initializing output file\n");
@@ -178,7 +206,7 @@ FILE* klog_initialize_file(
     const timepoint_t timepoint = klog_platform_get_current_timepoint();
 
     /* This is a null terminated string with all whitespace removed */
-    const char* const s_sanitized_prefix = klog_format_file_name_prefix(p_klog_file_info->s_filename_prefix);
+    const char* const s_sanitized_prefix = klog_format_file_name_prefix(p_klog_file_info->s_filename_prefix, cb_alloc);
 
     /* Filename's are formatted like: <prefix>_YYYYMMDD_HHMMSS_SSSS.log */
     /* Extra chars                  : 00+     123456789                 */
@@ -186,7 +214,7 @@ FILE* klog_initialize_file(
     /*                                20+                        012345 */
     const uint32_t prefix_length        = strlen(s_sanitized_prefix) + 1; /* +1 for null terminator */
     const uint32_t full_filename_length = prefix_length + 25 + 1; /* +1 for null terminator */
-    char* const    full_filename        = malloc(full_filename_length);
+    char* const    full_filename        = cb_alloc(full_filename_length);
     sprintf(
         full_filename,
         "%s_%.4d%.2d%.2d_%.2d%.2d%.2d_%.4d.log",

--- a/src/klog/klog_initialize.c
+++ b/src/klog/klog_initialize.c
@@ -15,13 +15,13 @@ char* klog_initialize_buffer(
     const uint32_t element_length_max,
     const char     fill_char,
     const bool     null_terminate,
-    void* (* const cb_alloc)(
+    void* (* const alloc_cb)(
         size_t size
     )
 ) {
     const uint32_t element_length_max_real = null_terminate ? element_length_max + 1 : element_length_max;
     const uint32_t total_size              = number_elements * element_length_max_real;
-    char* const    b_buffer                = cb_alloc(total_size);
+    char* const    b_buffer                = alloc_cb(total_size);
     memset(b_buffer, fill_char, total_size);
     if (null_terminate) {
         for (uint32_t i = 0; i < number_elements; ++i) {
@@ -82,11 +82,11 @@ bool klog_initialize_are_parameters_valid(
     }
 
     if (p_klog_alloc_info) {
-        if (p_klog_alloc_info->cb_alloc == NULL) {
+        if (p_klog_alloc_info->alloc_cb == NULL) {
             kdprintf("Trying to initialize klog with alloc info struct, yet the alloc callback is NULL\n");
             return false;
         }
-        if (p_klog_alloc_info->cb_free == NULL) {
+        if (p_klog_alloc_info->free_cb == NULL) {
             kdprintf("Trying to initialize klog with alloc info struct, yet the free callback is NULL\n");
             return false;
         }
@@ -100,12 +100,12 @@ bool klog_initialize_are_parameters_valid(
 
 KlogLoggerHandle* klog_initialize_logger_handle_array(
     const uint32_t max_number_loggers,
-    void* (* const cb_alloc)(
+    void* (* const alloc_cb)(
         size_t size
     )
 ) {
     const uint32_t          total_handle_array_size = max_number_loggers * sizeof(KlogLoggerHandle);
-    KlogLoggerHandle* const a_logger_handles        = cb_alloc(total_handle_array_size);
+    KlogLoggerHandle* const a_logger_handles        = alloc_cb(total_handle_array_size);
     kdprintf("Created logger handle array\n");
     kdprintf("  start: %p\n", (void*)a_logger_handles);
     kdprintf("  end  : %p\n", (void*)(a_logger_handles + total_handle_array_size));
@@ -116,12 +116,12 @@ KlogLoggerHandle* klog_initialize_logger_handle_array(
 
 uint8_t* klog_initialize_logger_levels_array(
     const uint32_t max_number_loggers,
-    void* (* const cb_alloc)(
+    void* (* const alloc_cb)(
         size_t size
     )
 ) {
     const uint32_t logger_levels_array_size_bytes = max_number_loggers * sizeof(uint8_t*);
-    uint8_t* const a_logger_levels                = cb_alloc(logger_levels_array_size_bytes);
+    uint8_t* const a_logger_levels                = alloc_cb(logger_levels_array_size_bytes);
     memset(a_logger_levels, 0, logger_levels_array_size_bytes);
 
     kdprintf("Created logger levels array\n");
@@ -133,12 +133,12 @@ uint8_t* klog_initialize_logger_levels_array(
 }
 
 char* klog_initialize_level_strings_buffer(
-    void* (*const cb_alloc)(
+    void* (*const alloc_cb)(
         size_t size
     )
 ) {
     const uint32_t level_string_array_total_bytes = G_klog_level_string_length * G_klog_number_levels;
-    char* const    b_level_strings                = cb_alloc(level_string_array_total_bytes);
+    char* const    b_level_strings                = alloc_cb(level_string_array_total_bytes);
     const char     off_string[]                   = "off  ";
     const char     fatal_string[]                 = "FATAL";
     const char     error_string[]                 = "ERROR";
@@ -163,12 +163,12 @@ char* klog_initialize_level_strings_buffer(
 }
 
 char* klog_initialize_colored_level_strings_buffer(
-    void* (*const cb_alloc)(
+    void* (*const alloc_cb)(
         size_t size
     )
 ) {
     const uint32_t colored_level_string_array_total_bytes = G_klog_colored_level_string_length * G_klog_number_levels;
-    char* const    b_colored_level_strings                = cb_alloc(colored_level_string_array_total_bytes);
+    char* const    b_colored_level_strings                = alloc_cb(colored_level_string_array_total_bytes);
     const char     off_string[]                           = "\x1b[37moff  \x1b[0m"; /* white  */
     const char     fatal_string[]                         = "\x1b[41mFATAL\x1b[0m"; /* red BG */
     const char     error_string[]                         = "\x1b[31mERROR\x1b[0m"; /* red    */
@@ -194,7 +194,7 @@ char* klog_initialize_colored_level_strings_buffer(
 
 FILE* klog_initialize_file(
     const KlogFileInfo* const p_klog_file_info,
-    void* (* const            cb_alloc)(
+    void* (* const            alloc_cb)(
         size_t size
     )
 ) {
@@ -206,7 +206,7 @@ FILE* klog_initialize_file(
     const timepoint_t timepoint = klog_platform_get_current_timepoint();
 
     /* This is a null terminated string with all whitespace removed */
-    const char* const s_sanitized_prefix = klog_format_file_name_prefix(p_klog_file_info->s_filename_prefix, cb_alloc);
+    const char* const s_sanitized_prefix = klog_format_file_name_prefix(p_klog_file_info->s_filename_prefix, alloc_cb);
 
     /* Filename's are formatted like: <prefix>_YYYYMMDD_HHMMSS_SSSS.log */
     /* Extra chars                  : 00+     123456789                 */
@@ -214,7 +214,7 @@ FILE* klog_initialize_file(
     /*                                20+                        012345 */
     const uint32_t prefix_length        = strlen(s_sanitized_prefix) + 1; /* +1 for null terminator */
     const uint32_t full_filename_length = prefix_length + 25 + 1; /* +1 for null terminator */
-    char* const    full_filename        = cb_alloc(full_filename_length);
+    char* const    full_filename        = alloc_cb(full_filename_length);
     sprintf(
         full_filename,
         "%s_%.4d%.2d%.2d_%.2d%.2d%.2d_%.4d.log",

--- a/src/klog/klog_initialize.h
+++ b/src/klog/klog_initialize.h
@@ -13,34 +13,51 @@ bool klog_initialize_are_parameters_valid(
     const KlogFormatInfo   klog_format_info,
     const KlogAsyncInfo*   p_klog_async_info,
     const KlogConsoleInfo* p_klog_console_info,
-    const KlogFileInfo*    p_klog_file_info
+    const KlogFileInfo*    p_klog_file_info,
+    const KlogAllocInfo*   p_klog_alloc_info
 );
 
 char* klog_initialize_buffer(
     const uint32_t number_elements,
     const uint32_t element_length_max,
     const char     fill_char,
-    const bool     null_terminate
+    const bool     null_terminate,
+    void* (* const cb_alloc)(
+        size_t size
+    )
 );
 
 KlogLoggerHandle* klog_initialize_logger_handle_array(
-    const uint32_t max_number_loggers
+    const uint32_t max_number_loggers,
+    void* (* const cb_alloc)(
+        size_t size
+    )
 );
 
 uint8_t* klog_initialize_logger_levels_array(
-    const uint32_t max_number_loggers
+    const uint32_t max_number_loggers,
+    void* (* const cb_alloc)(
+        size_t size
+    )
 );
 
 char* klog_initialize_level_strings_buffer(
-    void
+    void* (*const cb_alloc)(
+        size_t size
+    )
 );
 
 char* klog_initialize_colored_level_strings_buffer(
-    void
+    void* (*const cb_alloc)(
+        size_t size
+    )
 );
 
 FILE* klog_initialize_file(
-    const KlogFileInfo* p_klog_file_info
+    const KlogFileInfo* p_klog_file_info,
+    void* (* const      cb_alloc)(
+        size_t size
+    )
 );
 
 #endif /* KLOG_INITIALIZE_INCLUDED */

--- a/src/klog/klog_initialize.h
+++ b/src/klog/klog_initialize.h
@@ -22,40 +22,40 @@ char* klog_initialize_buffer(
     const uint32_t element_length_max,
     const char     fill_char,
     const bool     null_terminate,
-    void* (* const cb_alloc)(
+    void* (* const alloc_cb)(
         size_t size
     )
 );
 
 KlogLoggerHandle* klog_initialize_logger_handle_array(
     const uint32_t max_number_loggers,
-    void* (* const cb_alloc)(
+    void* (* const alloc_cb)(
         size_t size
     )
 );
 
 uint8_t* klog_initialize_logger_levels_array(
     const uint32_t max_number_loggers,
-    void* (* const cb_alloc)(
+    void* (* const alloc_cb)(
         size_t size
     )
 );
 
 char* klog_initialize_level_strings_buffer(
-    void* (*const cb_alloc)(
+    void* (*const alloc_cb)(
         size_t size
     )
 );
 
 char* klog_initialize_colored_level_strings_buffer(
-    void* (*const cb_alloc)(
+    void* (*const alloc_cb)(
         size_t size
     )
 );
 
 FILE* klog_initialize_file(
     const KlogFileInfo* p_klog_file_info,
-    void* (* const      cb_alloc)(
+    void* (* const      alloc_cb)(
         size_t size
     )
 );

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -21,6 +21,7 @@ extern struct KlogConfig {
     KlogAsyncInfo   async;
     KlogConsoleInfo console;
     KlogFileInfo    file;
+    KlogAllocInfo   alloc;
 } g_klog_config;
 
 /**

--- a/src/klog/ut/ut-klog_alloc_callback_counts.c
+++ b/src/klog/ut/ut-klog_alloc_callback_counts.c
@@ -1,0 +1,116 @@
+/**
+ * @brief Ensure the allocation/free callbacks get called a specific number of times, according to
+ * the actual number of allocations we should be making. Also ensure the alloc and free callbacks
+ * are called the same number of times as eachother.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "klog/klog.h"
+
+#include "../klog_state.h"
+#include "../klog_handle.h"
+
+/**
+ * @brief These are the counters for how many times each callback has been invoked.
+ */
+uint32_t g_alloc_counter = 0;
+uint32_t g_free_counter  = 0;
+
+/**
+ * @brief These are the wrappers which increment the counter
+ */
+void* malloc_wrapper(
+    const size_t size
+) {
+    void* result = malloc(size);
+
+    printf("Allocation index %d - size %ld bytes - result %p\n", g_alloc_counter, size, result);
+
+    g_alloc_counter += 1;
+
+    return result;
+}
+
+void free_wrapper(
+    void* p
+) {
+    printf("Free index %d - freeing %p\n", g_free_counter, p);
+    g_free_counter += 1;
+    free(p);
+}
+
+int check(
+    void
+) {
+    /* Reset the counters before the test */
+    g_alloc_counter = 0;
+    g_free_counter  = 0;
+
+    const uint32_t max_number_loggers = 2;
+    const uint32_t max_name_length    = 3;
+
+    const KlogAllocInfo alloc_info = { &malloc_wrapper, &free_wrapper };
+
+    klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, NULL, NULL, NULL, &alloc_info);
+
+    /* check post initialization values */
+    const uint32_t alloc_counter_init_expected = 10;
+    if (g_alloc_counter != alloc_counter_init_expected) {
+        printf("Alloc counter is %d after initialization when it should be %d\n", g_alloc_counter, alloc_counter_init_expected);
+        return 1;
+    }
+    const uint32_t free_counter_init_expected = 0;
+    if (g_free_counter != free_counter_init_expected) {
+        printf("Free counter is %d after initialization when it should be %d\n", g_free_counter, free_counter_init_expected);
+        return 1;
+    }
+
+    /* create loggers because this does some allocation for now */
+    printf("Creating logger 0\n");
+    const KlogLoggerHandle* p_handle_0 = klog_logger_create("ABC");
+    printf("Creating logger 1\n");
+    const KlogLoggerHandle* p_handle_1 = klog_logger_create("DEF");
+
+    /* logging should introduce no allocs or frees */
+    printf("Logging with logger 0\n");
+    klog(p_handle_0, KLOG_LEVEL_INFO, "Beep \"%s\"\n", "hello");
+    printf("Logging with logger 1\n");
+    klog(p_handle_1, KLOG_LEVEL_INFO, "Boop \"%s\"\n", "world");
+
+    /* check post logger creation values */
+    const uint32_t alloc_counter_created_expected = alloc_counter_init_expected + 2;
+    if (g_alloc_counter != alloc_counter_created_expected) {
+        printf("Alloc counter is %d after logger creations when it should be %d\n", g_alloc_counter, alloc_counter_created_expected);
+        return 1;
+    }
+    const uint32_t free_counter_created_expected = free_counter_init_expected + 2;
+    if (g_free_counter != free_counter_created_expected) {
+        printf("Free counter is %d after logger creations when it should be %d\n", g_free_counter, free_counter_created_expected);
+        return 1;
+    }
+
+    /* deinitialize because this should invoke free many times, but not alloc */
+    klog_deinitialize();
+
+    /* check post deinit values */
+    const uint32_t alloc_counter_deinit_expected = alloc_counter_created_expected;
+    if (g_alloc_counter != alloc_counter_deinit_expected) {
+        printf("Alloc counter is %d after deinitializtion when it should be %d\n", g_alloc_counter, alloc_counter_deinit_expected);
+        return 1;
+    }
+    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 10;
+    if (g_free_counter != free_counter_deinit_expected) {
+        printf("Free counter is %d after deinitialization when it should be %d\n", g_free_counter, free_counter_deinit_expected);
+        return 1;
+    }
+
+    return 0;
+}
+
+int main(
+    void
+) {
+    return check();
+}

--- a/src/klog/ut/ut-klog_alloc_callback_counts.c
+++ b/src/klog/ut/ut-klog_alloc_callback_counts.c
@@ -106,6 +106,12 @@ int check(
         return 1;
     }
 
+    /* The alloc and free callbacks should be used the same number of times */
+    if (g_alloc_counter != g_free_counter) {
+        printf("Alloc counter is %d while Free counter is %d. These should be the same\n", g_alloc_counter, g_free_counter);
+        return 1;
+    }
+
     return 0;
 }
 

--- a/src/klog/ut/ut-klog_deinitialize.c
+++ b/src/klog/ut/ut-klog_deinitialize.c
@@ -42,12 +42,12 @@ int check(
     klog_initialize(4, format_info, &async_info, &console_info, &file_info, NULL);
 
     /* Ensure allocation/free callbacks were defaulted correctly */
-    if (g_klog_config.alloc.cb_alloc != &malloc) {
-        printf("g_klog_config.alloc.cb_alloc should by default equal the address of malloc but it does not\n");
+    if (g_klog_config.alloc.alloc_cb != &malloc) {
+        printf("g_klog_config.alloc.alloc_cb should by default equal the address of malloc but it does not\n");
         return 1;
     }
-    if (g_klog_config.alloc.cb_free != &free) {
-        printf("g_klog_config.alloc.cb_free should by default equal the address of free but it does not\n");
+    if (g_klog_config.alloc.free_cb != &free) {
+        printf("g_klog_config.alloc.free_cb should by default equal the address of free but it does not\n");
         return 1;
     }
 
@@ -93,12 +93,12 @@ int callbacks(
     klog_initialize(4, format_info, NULL, NULL, NULL, &alloc_info);
 
     /* Ensure allocation/free callbacks were set correctly */
-    if (g_klog_config.alloc.cb_alloc != &dummy_malloc) {
-        printf("g_klog_config.alloc.cb_alloc should equal the address of dummy_malloc but it does not\n");
+    if (g_klog_config.alloc.alloc_cb != &dummy_malloc) {
+        printf("g_klog_config.alloc.alloc_cb should equal the address of dummy_malloc but it does not\n");
         return 1;
     }
-    if (g_klog_config.alloc.cb_free != &dummy_free) {
-        printf("g_klog_config.alloc.cb_free should equal the address of dummy_free but it does not\n");
+    if (g_klog_config.alloc.free_cb != &dummy_free) {
+        printf("g_klog_config.alloc.free_cb should equal the address of dummy_free but it does not\n");
         return 1;
     }
 

--- a/src/klog/ut/ut-klog_deinitialize.c
+++ b/src/klog/ut/ut-klog_deinitialize.c
@@ -41,6 +41,16 @@ int check(
     KlogFileInfo    file_info    = { KLOG_LEVEL_TRACE, "BASIC\tPREFIX" };
     klog_initialize(4, format_info, &async_info, &console_info, &file_info, NULL);
 
+    /* Ensure allocation/free callbacks were defaulted correctly */
+    if (g_klog_config.alloc.cb_alloc != &malloc) {
+        printf("g_klog_config.alloc.cb_alloc should by default equal the address of malloc but it does not\n");
+        return 1;
+    }
+    if (g_klog_config.alloc.cb_free != &free) {
+        printf("g_klog_config.alloc.cb_free should by default equal the address of free but it does not\n");
+        return 1;
+    }
+
     /* Create the expected empty state */
     struct KlogConfig klog_config_empty = { 0 };
     struct KlogState  klog_state_empty  = { 0 };

--- a/src/klog/ut/ut-klog_deinitialize.c
+++ b/src/klog/ut/ut-klog_deinitialize.c
@@ -27,7 +27,7 @@ int check(
     KlogFormatInfo  format_info  = { 6, 100, 10, true, true };
     KlogConsoleInfo console_info = { KLOG_LEVEL_INFO, true };
     KlogFileInfo    file_info    = { KLOG_LEVEL_TRACE, "BASIC\tPREFIX" };
-    klog_initialize(4, format_info, &async_info, &console_info, &file_info);
+    klog_initialize(4, format_info, &async_info, &console_info, &file_info, NULL);
 
     /* Create the expected empty state */
     struct KlogConfig klog_config_empty = { 0 };

--- a/src/klog/ut/ut-klog_deinitialize.c
+++ b/src/klog/ut/ut-klog_deinitialize.c
@@ -10,6 +10,18 @@
 #include "klog/klog.h"
 #include "../klog_state.h"
 
+void* dummy_malloc(
+    const size_t size
+) {
+    return malloc(size);
+}
+
+void dummy_free(
+    void* p
+) {
+    free(p);
+}
+
 void print_memory(
     const void* const p_actual,
     const void* const p_expected,
@@ -63,6 +75,57 @@ int check(
     return 0;
 }
 
+int callbacks(
+    void
+) {
+    KlogFormatInfo format_info = { 6, 100, 10, true, true };
+    KlogAllocInfo  alloc_info  = { &dummy_malloc, &dummy_free };
+    klog_initialize(4, format_info, NULL, NULL, NULL, &alloc_info);
+
+    /* Ensure allocation/free callbacks were set correctly */
+    if (g_klog_config.alloc.cb_alloc != &dummy_malloc) {
+        printf("g_klog_config.alloc.cb_alloc should equal the address of dummy_malloc but it does not\n");
+        return 1;
+    }
+    if (g_klog_config.alloc.cb_free != &dummy_free) {
+        printf("g_klog_config.alloc.cb_free should equal the address of dummy_free but it does not\n");
+        return 1;
+    }
+
+    /* Create the expected empty state */
+    struct KlogConfig klog_config_empty = { 0 };
+    struct KlogState  klog_state_empty  = { 0 };
+
+    /* Check that we are not equivelant to null */
+    if (memcmp(&g_klog_config, &klog_config_empty, sizeof(klog_config_empty)) == 0) {
+        printf("g_klog_config should not be empty after klog_initialize\n");
+        print_memory(&g_klog_config, &klog_config_empty, sizeof(klog_config_empty));
+        return 1;
+    }
+    if (memcmp(&g_klog_state, &klog_state_empty, sizeof(klog_state_empty)) == 0) {
+        printf("g_klog_state should not be empty after klog_initialize\n");
+        print_memory(&g_klog_state, &klog_state_empty, sizeof(klog_state_empty));
+        return 1;
+    }
+
+    /* Deinitialize */
+    klog_deinitialize();
+
+    /* Check that we **are** equivelant to null */
+    if (memcmp(&g_klog_config, &klog_config_empty, sizeof(klog_config_empty)) != 0) {
+        printf("g_klog_config should be empty after klog_deinitialize\n");
+        print_memory(&g_klog_config, &klog_config_empty, sizeof(klog_config_empty));
+        return 1;
+    }
+    if (memcmp(&g_klog_state, &klog_state_empty, sizeof(klog_state_empty)) != 0) {
+        printf("g_klog_state should be empty after klog_deinitialize\n");
+        print_memory(&g_klog_state, &klog_state_empty, sizeof(klog_state_empty));
+        return 1;
+    }
+
+    return 0;
+}
+
 int noop(
     void
 ) {
@@ -72,7 +135,7 @@ int noop(
 int main(
     void
 ) {
-    int result = check() || noop();
+    int result = check() || callbacks() || noop();
 
     return result;
 }

--- a/src/klog/ut/ut-klog_format_logger_name.c
+++ b/src/klog/ut/ut-klog_format_logger_name.c
@@ -17,7 +17,7 @@ int remove_whitespace(
 
     const char* s_expected = "a_b_c_d_e_f__g____h";
 
-    const char* s_actual = klog_format_logger_name(s_input);
+    const char* s_actual = klog_format_logger_name(s_input, &malloc);
 
     int result = strcmp(s_input, s_expected);
 

--- a/src/klog/ut/ut-klog_initialize_level_strings_buffer.c
+++ b/src/klog/ut/ut-klog_initialize_level_strings_buffer.c
@@ -7,7 +7,7 @@
 int validate(
     void
 ) {
-    char* b_level_strings = klog_initialize_level_strings_buffer();
+    char* b_level_strings = klog_initialize_level_strings_buffer(&malloc);
 
     int result = 0;
 
@@ -34,7 +34,7 @@ int validate(
 int validate_colors(
     void
 ) {
-    char* b_level_strings_colored = klog_initialize_colored_level_strings_buffer();
+    char* b_level_strings_colored = klog_initialize_colored_level_strings_buffer(&malloc);
 
     int result = 0;
 

--- a/src/klog/ut/ut-klog_initialize_parameters_are_valid.c
+++ b/src/klog/ut/ut-klog_initialize_parameters_are_valid.c
@@ -55,7 +55,7 @@ int no_alloc_cb(
 ) {
     KlogAllocInfo alloc_info = { NULL, &free };
     if (klog_initialize_are_parameters_valid(false, 10, (KlogFormatInfo) { 10, 0, 0, false, false }, NULL, NULL, NULL, &alloc_info)) {
-        printf("Parameters should be invalid when KlogAllocInfo pointer is provided but cb_alloc is NULL\n");
+        printf("Parameters should be invalid when KlogAllocInfo pointer is provided but alloc_cb is NULL\n");
         return 1;
     }
 
@@ -67,7 +67,7 @@ int no_free_cb(
 ) {
     KlogAllocInfo alloc_info = { &malloc, NULL };
     if (klog_initialize_are_parameters_valid(false, 10, (KlogFormatInfo) { 10, 0, 0, false, false }, NULL, NULL, NULL, &alloc_info)) {
-        printf("Parameters should be invalid when KlogAllocInfo pointer is provided but cb_free is NULL\n");
+        printf("Parameters should be invalid when KlogAllocInfo pointer is provided but free_cb is NULL\n");
         return 1;
     }
 

--- a/src/klog/ut/ut-klog_initialize_parameters_are_valid.c
+++ b/src/klog/ut/ut-klog_initialize_parameters_are_valid.c
@@ -8,7 +8,7 @@
 int already_initialized(
     void
 ) {
-    if (klog_initialize_are_parameters_valid(true, 0, (KlogFormatInfo) { 0 }, NULL, NULL, NULL)) {
+    if (klog_initialize_are_parameters_valid(true, 0, (KlogFormatInfo) { 0 }, NULL, NULL, NULL, NULL)) {
         printf("Parameters should be invalid when klog is already initialized\n");
         return 1;
     }
@@ -19,7 +19,7 @@ int already_initialized(
 int no_loggers(
     void
 ) {
-    if (klog_initialize_are_parameters_valid(false, 0, (KlogFormatInfo) { 0 }, NULL, NULL, NULL)) {
+    if (klog_initialize_are_parameters_valid(false, 0, (KlogFormatInfo) { 0 }, NULL, NULL, NULL, NULL)) {
         printf("Parameters should be invalid when the maximum number of loggers is set to 0\n");
         return 1;
     }
@@ -30,7 +30,7 @@ int no_loggers(
 int no_logger_name_length(
     void
 ) {
-    if (klog_initialize_are_parameters_valid(false, 10, (KlogFormatInfo) { 0, 100, 0, false, false }, NULL, NULL, NULL)) {
+    if (klog_initialize_are_parameters_valid(false, 10, (KlogFormatInfo) { 0, 100, 0, false, false }, NULL, NULL, NULL, NULL)) {
         printf("Parameters should be invalid when the maximum length of logger names is set to 0\n");
         return 1;
     }
@@ -41,7 +41,7 @@ int no_logger_name_length(
 int no_message_length(
     void
 ) {
-    if (klog_initialize_are_parameters_valid(false, 10, (KlogFormatInfo) { 10, 0, 0, false, false }, NULL, NULL, NULL)) {
+    if (klog_initialize_are_parameters_valid(false, 10, (KlogFormatInfo) { 10, 0, 0, false, false }, NULL, NULL, NULL, NULL)) {
         printf("Parameters should be invalid when the maximum length of a message is set to 0\n");
         return 1;
     }
@@ -52,7 +52,7 @@ int no_message_length(
 int valid(
     void
 ) {
-    if (!klog_initialize_are_parameters_valid(false, 10, (KlogFormatInfo) { 10, 100, 0, false, false }, NULL, NULL, NULL)) {
+    if (!klog_initialize_are_parameters_valid(false, 10, (KlogFormatInfo) { 10, 100, 0, false, false }, NULL, NULL, NULL, NULL)) {
         printf("Parameters should be valid\n");
         return 1;
     }

--- a/src/klog/ut/ut-klog_initialize_parameters_are_valid.c
+++ b/src/klog/ut/ut-klog_initialize_parameters_are_valid.c
@@ -1,5 +1,6 @@
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "klog/klog.h"
 
@@ -49,11 +50,41 @@ int no_message_length(
     return 0;
 }
 
+int no_alloc_cb(
+    void
+) {
+    KlogAllocInfo alloc_info = { NULL, &free };
+    if (klog_initialize_are_parameters_valid(false, 10, (KlogFormatInfo) { 10, 0, 0, false, false }, NULL, NULL, NULL, &alloc_info)) {
+        printf("Parameters should be invalid when KlogAllocInfo pointer is provided but cb_alloc is NULL\n");
+        return 1;
+    }
+
+    return 0;
+}
+
+int no_free_cb(
+    void
+) {
+    KlogAllocInfo alloc_info = { &malloc, NULL };
+    if (klog_initialize_are_parameters_valid(false, 10, (KlogFormatInfo) { 10, 0, 0, false, false }, NULL, NULL, NULL, &alloc_info)) {
+        printf("Parameters should be invalid when KlogAllocInfo pointer is provided but cb_free is NULL\n");
+        return 1;
+    }
+
+    return 0;
+}
+
 int valid(
     void
 ) {
     if (!klog_initialize_are_parameters_valid(false, 10, (KlogFormatInfo) { 10, 100, 0, false, false }, NULL, NULL, NULL, NULL)) {
-        printf("Parameters should be valid\n");
+        printf("Parameters should be valid - case 0\n");
+        return 1;
+    }
+
+    KlogAllocInfo alloc_info = { &malloc, &free };
+    if (!klog_initialize_are_parameters_valid(false, 10, (KlogFormatInfo) { 10, 100, 0, false, false }, NULL, NULL, NULL, &alloc_info)) {
+        printf("Parameters should be valid - case 1\n");
         return 1;
     }
 
@@ -69,7 +100,14 @@ int noop(
 int main(
     void
 ) {
-    const int result = already_initialized() || no_loggers() || no_message_length() || no_message_length() || valid() || noop()
+    const int result = already_initialized()
+        || no_loggers()
+        || no_message_length()
+        || no_message_length()
+        || no_alloc_cb()
+        || no_free_cb()
+        || valid()
+        || noop()
     ;
 
     return result;

--- a/src/klog/ut/ut-klog_logger_create.c
+++ b/src/klog/ut/ut-klog_logger_create.c
@@ -17,7 +17,7 @@ int create_single_logger(
 ) {
     const uint32_t max_number_loggers = 1;
     const uint32_t max_name_length    = 3;
-    klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, NULL, NULL, NULL);
+    klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, NULL, NULL, NULL, NULL);
 
     if (g_klog_state.number_loggers_max != max_number_loggers) {
         printf("Klog initialized with max number of loggers %d instead of %d\n", g_klog_state.number_loggers_max, max_number_loggers);
@@ -49,7 +49,7 @@ int create_multiple_loggers(
 ) {
     const uint32_t max_number_loggers = 100;
     const uint32_t max_name_length    = 3;
-    klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, NULL, NULL, NULL);
+    klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, NULL, NULL, NULL, NULL);
 
     if (g_klog_state.number_loggers_max != max_number_loggers) {
         printf("Klog initialized with max number of loggers %d instead of %d\n", g_klog_state.number_loggers_max, max_number_loggers);

--- a/src/klog/ut/ut-klog_logger_level_set.c
+++ b/src/klog/ut/ut-klog_logger_level_set.c
@@ -20,7 +20,7 @@ int set_levels(
 ) {
     const uint32_t max_number_loggers = 100;
     const uint32_t max_name_length    = 3;
-    klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, NULL, NULL, NULL);
+    klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, NULL, NULL, NULL, NULL);
 
     for (uint32_t i = 0; i < max_number_loggers; ++i) {
         const uint32_t desired_level = i % KLOG_LEVEL_COUNT;
@@ -51,7 +51,7 @@ int log_levels_tempfile(
     const uint32_t     max_number_loggers = 100;
     const uint32_t     max_name_length    = 3;
     const KlogFileInfo file_info          = { KLOG_LEVEL_TRACE, "/tmp/ut-klog_logger_level_set" }; /* @todo kjk 2026/02/11 portable tempfile path for windows and mac */
-    klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, NULL, NULL, &file_info);
+    klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, NULL, NULL, &file_info, NULL);
 
     const char*             l_names[KLOG_LEVEL_COUNT]   = { "001", "002", "003", "004", "005", "006", "007" };
     const KlogLoggerHandle* a_handles[KLOG_LEVEL_COUNT] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL };

--- a/src/klog/ut/ut-klog_prefix_buffer_usage.c
+++ b/src/klog/ut/ut-klog_prefix_buffer_usage.c
@@ -13,7 +13,7 @@ int no_async_param(
     const uint32_t  logger_name_length = 6;
     KlogFormatInfo  format_info        = { logger_name_length, 10, 0, false, false };
     KlogConsoleInfo console_info       = { KLOG_LEVEL_TRACE, false };
-    klog_initialize(5, format_info, NULL, &console_info, NULL);
+    klog_initialize(5, format_info, NULL, &console_info, NULL, NULL);
 
     if (g_klog_state.prefix_element_index != 0) {
         printf("Klog prefix element index should be 0 before anything is logged\n");
@@ -95,7 +95,7 @@ int single_element(
     KlogFormatInfo  format_info        = { logger_name_length, 10, 0, false, false };
     KlogAsyncInfo   async_info         = { 1, 3 };
     KlogConsoleInfo console_info       = { KLOG_LEVEL_INFO, false };
-    klog_initialize(5, format_info, &async_info, &console_info, NULL);
+    klog_initialize(5, format_info, &async_info, &console_info, NULL, NULL);
 
     if (g_klog_state.prefix_element_index != 0) {
         printf("Klog prefix element index should be 0 before anything is logged\n");
@@ -179,7 +179,7 @@ int multiple_elements(
     KlogFormatInfo  format_info        = { logger_name_length, 10, 0, false, false };
     KlogAsyncInfo   async_info         = { num_elements, 3 };
     KlogConsoleInfo console_info       = { KLOG_LEVEL_DEBUG, false };
-    klog_initialize(num_loggers, format_info, &async_info, &console_info, NULL);
+    klog_initialize(num_loggers, format_info, &async_info, &console_info, NULL, NULL);
 
     if (g_klog_state.prefix_element_index != 0) {
         printf("Klog prefix element index should be 0 before anything is logged\n");


### PR DESCRIPTION
# v0.0.13 Support custom memory allocation and free logic via callbacks (add KlogAllocInfo)

<!--
Include updated version, and use imperative mood.
Ex:

v1.2.3 rename boop to beep
-->

---

## Description

<!--
What does this change do?

- Describe the previous behavior and why it was bad.
- Describe the updated behavior and why it is good.
-->

This change introduces a new struct for the user to provide upon initialization, `KlogAllocInfo`. This struct contains function pointers to a malloc and free function, allowing the user to provide their own implementations of allocation and free functions. 

### Implementation Details

<!--
What changes were made in order to get the desired, updated behavior?

- Give details that will help reviewers understand what is going on.
-->

- The user may provide a `KlogAllocInfo` struct to the klog initialization function
- If the `KlogAllocInfo` struct is provided to the initialization function, then the given callbacks are stored as global variables
    - If not provided, `malloc` and `free` are saved to the global variables
- The global allocation and free callbacks are passed via parameter to every non-top-level function which needs allocation and free logic 

---

## Motivation

<!--
Why is this change needed?

- What problem does it solve?
- Why is this the correct fix? Why not alternative approaches?
-->

Users may be operating in a high performance environment, where allocating memory in the traditional way is not performant enough. Think of the case of a user who has a memory arena they want to use.

### Related Issues

<!--
Which issues does this close? Ex:

- closes #1
- closes #42
-->

- closes #38 

---

## Testing

<!--
How was this validated?

- Were new tests added? If so, which ones?
- Which currently in place tests are relevant?
- Include logs, traces, or minimal repro steps if applicable.
-->

- `ut-klog_deinitialize.c` has been updated to ensure we default the callbacks correctly, to ensure the callbacks do get set to the functions we specify, and to ensure that the callbacks get cleared correctly
- `ut-klog_initialize_parameters_are_valid.c` has been updated to ensure that a `KlogAllocInfo` struct must contain both function pointers if the struct is provided
- `ut-klog_allocation_callback_counts.c` was added to ensure that the allocation and free callbacks are used the correct number of times based on the operations which would invoke them, and to ensure that the number of times we alloc is the same number of times that we free

---

## Checklist

- [x] Adherance to style guide (naming and formatting)
- [x] All tests pass
- [x] New tests added where appropriate
- [x] Documentation updated (everything exposed in headers really)
- [x] Concurrency implications considered
- [x] Self review performed
- [x] Version incremented if appropriate

---
