### PR TITLE
v0.0.14 Ring buffer for formatted messages

### DIFF
--- a/cmake/KlogVersion.cmake
+++ b/cmake/KlogVersion.cmake
@@ -17,4 +17,5 @@ endfunction()
 # set_klog_versions(0 0 10) # Formatting
 # set_klog_versions(0 0 11) # EOF Newlines
 # set_klog_versions(0 0 12) # Pre-allocate message buffer, don't malloc for message formatting
-set_klog_versions(0 0 13) # Allow users to specify callbacks for custom allocation and free logic
+# set_klog_versions(0 0 13) # Allow users to specify callbacks for custom allocation and free logic
+set_klog_versions(0 0 14) # Pre-allocate multiple formatted input message buffer to prep for multi-threading support

--- a/src/klog/CMakeLists.txt
+++ b/src/klog/CMakeLists.txt
@@ -39,7 +39,7 @@ if (KLOG_BUILD_TESTS)
     create_unit_test_plain(ut/ut-klog_initialize_level_strings_buffer.c klog)
     create_unit_test_plain(ut/ut-klog_logger_create.c klog)
     create_unit_test_plain(ut/ut-klog_logger_level_set.c klog)
-    create_unit_test_plain(ut/ut-klog_prefix_buffer_usage.c klog)
+    create_unit_test_plain(ut/ut-klog_ring_buffer_usage.c klog)
 
     create_functional_test(ft/ft-klog_basic.c klog)
     create_functional_test(ft/ft-klog_console.c klog)

--- a/src/klog/ft/ft-klog_basic.c
+++ b/src/klog/ft/ft-klog_basic.c
@@ -42,12 +42,13 @@ int main(
     kdprintf("LOGGING MULTIPLE LINES\n");
     klog(handle_1, KLOG_LEVEL_INFO, "1234\nabcd\n0987\nABCD\n!@#$\n)(*&\n)dsdfsfsfsfsfsfsfs");
     klog(handle_1, KLOG_LEVEL_WARN, "\n1\n2\n3\n4\n5 ha ha many lines \n1\n2\n3\n ha");
-    kdprintf("LOGGING EMPTY LINES\n");
+    kdprintf("LOGGING 3 EMPTY LINES\n");
+    klog(handle_1, KLOG_LEVEL_WARN, "LOGGING 3 EMPTY LINES");
     klog(handle_1, KLOG_LEVEL_WARN, "");
     klog(handle_1, KLOG_LEVEL_WARN, "");
     klog(handle_1, KLOG_LEVEL_WARN, "");
-    klog(handle_1, KLOG_LEVEL_WARN, "");
-    klog(handle_1, KLOG_LEVEL_WARN, "");
+    kdprintf("DONE LOGGING 3 EMPTY LINES\n");
+    klog(handle_1, KLOG_LEVEL_WARN, "DONE LOGGING 3 EMPTY LINES");
 
 #ifndef KLOG_DEBUG
     const KlogLoggerHandle* handle_2 = klog_logger_create("B");

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -160,8 +160,8 @@ void klog_initialize(
     );
 
     g_klog_state.message_formatted_max_size = g_klog_config.format.message_max_length;
-    g_klog_state.b_message_formatted        = klog_initialize_buffer(
-        1,
+    g_klog_state.b_messages_formatted       = klog_initialize_buffer(
+        g_klog_state.prefix_element_count,
         g_klog_state.message_formatted_max_size,
         '\0',
         true,
@@ -221,8 +221,8 @@ void klog_deinitialize(
     g_klog_state.b_prefixes_source_location = NULL;
 
     g_klog_state.message_formatted_max_size = 0;
-    g_klog_config.alloc.free_cb(g_klog_state.b_message_formatted);
-    g_klog_state.b_message_formatted = NULL;
+    g_klog_config.alloc.free_cb(g_klog_state.b_messages_formatted);
+    g_klog_state.b_messages_formatted = NULL;
 
     if (g_klog_state.p_file) {
         fclose(g_klog_state.p_file);
@@ -357,10 +357,12 @@ void klog_log(
     const KlogString packed_time = g_klog_config.format.use_timestamp ? klog_format_time(s_prefix_time) : (KlogString) { 0, NULL };
 
     /* Create the input string with the arguments injected */
+    char* s_message_formatted = g_klog_state.b_messages_formatted
+        + (g_klog_state.prefix_element_index * g_klog_state.message_formatted_max_size);
     va_list p_args;
     va_start(p_args, s_format);
     const uint32_t actual_message_length = klog_format_input_message(
-        g_klog_state.b_message_formatted,
+        s_message_formatted,
         g_klog_state.message_formatted_max_size,
         s_format,
         p_args
@@ -418,12 +420,12 @@ void klog_log(
     /* Actually log the message */
     uint32_t i_starting_character = 0;
     while (i_starting_character <= actual_message_length) {
-        const char* const p_newline         = strchr(g_klog_state.b_message_formatted + i_starting_character, '\n');
+        const char* const p_newline         = strchr(s_message_formatted + i_starting_character, '\n');
         const uint32_t    submessage_length = p_newline
-            ? p_newline - (g_klog_state.b_message_formatted + i_starting_character)
+            ? p_newline - (s_message_formatted + i_starting_character)
             : actual_message_length;
 
-        const KlogString packed_message = { submessage_length, g_klog_state.b_message_formatted + i_starting_character };
+        const KlogString packed_message = { submessage_length, s_message_formatted + i_starting_character };
         if (requested_level <= g_klog_config.console.max_level) {
             klog_output_console(&packed_prefix_console, &packed_message);
         }
@@ -441,6 +443,6 @@ void klog_log(
     }
 
     /* Clear the buffer for the next time it is used */
-    memset(g_klog_state.b_message_formatted, 0, g_klog_state.message_formatted_max_size);
+    memset(s_message_formatted, 0, g_klog_state.message_formatted_max_size);
 #endif
 }

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -124,35 +124,35 @@ void klog_initialize(
     );
     g_klog_state.prefix_time_size            = G_klog_time_string_length;
     g_klog_state.prefix_source_location_size = g_klog_config.format.source_location_filename_max_length + 4 + 1; /* 4 digit line number, colon */
-    g_klog_state.prefix_element_index        = 0;
+    g_klog_state.message_element_idx         = 0;
     if (p_klog_async_info) {
-        g_klog_state.prefix_element_count = p_klog_async_info->message_queue_number_elements;
+        g_klog_state.message_element_count = p_klog_async_info->message_queue_number_elements;
     } else {
-        g_klog_state.prefix_element_count = 1;
+        g_klog_state.message_element_count = 1;
     }
     g_klog_state.b_prefixes_file = klog_initialize_buffer(
-        g_klog_state.prefix_element_count,
+        g_klog_state.message_element_count,
         g_klog_state.prefix_file_size,
         '\0',
         true,
         g_klog_config.alloc.alloc_cb
     );
     g_klog_state.b_prefixes_console = klog_initialize_buffer(
-        g_klog_state.prefix_element_count,
+        g_klog_state.message_element_count,
         g_klog_state.prefix_console_size,
         '\0',
         true,
         g_klog_config.alloc.alloc_cb
     );
     g_klog_state.b_prefixes_time = klog_initialize_buffer(
-        g_klog_state.prefix_element_count,
+        g_klog_state.message_element_count,
         g_klog_state.prefix_time_size,
         '$',
         true,
         g_klog_config.alloc.alloc_cb
     );
     g_klog_state.b_prefixes_source_location = klog_initialize_buffer(
-        g_klog_state.prefix_element_count,
+        g_klog_state.message_element_count,
         g_klog_state.prefix_source_location_size,
         '@',
         true,
@@ -161,7 +161,7 @@ void klog_initialize(
 
     g_klog_state.message_formatted_max_size = g_klog_config.format.message_max_length;
     g_klog_state.b_messages_formatted       = klog_initialize_buffer(
-        g_klog_state.prefix_element_count,
+        g_klog_state.message_element_count,
         g_klog_state.message_formatted_max_size,
         '\0',
         true,
@@ -201,8 +201,8 @@ void klog_deinitialize(
     g_klog_state.b_level_strings         = NULL;
     g_klog_state.b_level_strings_colored = NULL;
 
-    g_klog_state.prefix_element_index = 0;
-    g_klog_state.prefix_element_count = 0;
+    g_klog_state.message_element_idx   = 0;
+    g_klog_state.message_element_count = 0;
 
     g_klog_state.prefix_file_size = 0;
     g_klog_config.alloc.free_cb(g_klog_state.b_prefixes_file);
@@ -352,13 +352,13 @@ void klog_log(
     }
 
     /* We are getting the time first, so it's closest to the actual point of invocation */
-    char* s_prefix_time = g_klog_state.b_prefixes_time + (g_klog_state.prefix_element_index * g_klog_state.prefix_time_size);
+    char* s_prefix_time = g_klog_state.b_prefixes_time + (g_klog_state.message_element_idx * g_klog_state.prefix_time_size);
     memset(s_prefix_time, '\0', g_klog_state.prefix_time_size);
     const KlogString packed_time = g_klog_config.format.use_timestamp ? klog_format_time(s_prefix_time) : (KlogString) { 0, NULL };
 
     /* Create the input string with the arguments injected */
     char* s_message_formatted = g_klog_state.b_messages_formatted
-        + (g_klog_state.prefix_element_index * g_klog_state.message_formatted_max_size);
+        + (g_klog_state.message_element_idx * g_klog_state.message_formatted_max_size);
     va_list p_args;
     va_start(p_args, s_format);
     const uint32_t actual_message_length = klog_format_input_message(
@@ -383,7 +383,7 @@ void klog_log(
     const KlogString* const p_packed_level_console = g_klog_config.console.use_color ? &packed_level_color : &packed_level_file;
 
     char* s_prefix_source_location = g_klog_state.b_prefixes_source_location
-        + (g_klog_state.prefix_element_index * g_klog_state.prefix_source_location_size);
+        + (g_klog_state.message_element_idx * g_klog_state.prefix_source_location_size);
     const KlogString packed_source_location = (g_klog_config.format.source_location_filename_max_length && s_filename)
         ? klog_format_source_location(
                 s_prefix_source_location,
@@ -394,8 +394,8 @@ void klog_log(
         : (KlogString) { 0, NULL };
 
     /* Get the pointers to the prefix buffers and reset them in preparation for setting */
-    char* s_prefix_file    = g_klog_state.b_prefixes_file + (g_klog_state.prefix_element_index * g_klog_state.prefix_file_size);
-    char* s_prefix_console = g_klog_state.b_prefixes_console + (g_klog_state.prefix_element_index * g_klog_state.prefix_console_size);
+    char* s_prefix_file    = g_klog_state.b_prefixes_file + (g_klog_state.message_element_idx * g_klog_state.prefix_file_size);
+    char* s_prefix_console = g_klog_state.b_prefixes_console + (g_klog_state.message_element_idx * g_klog_state.prefix_console_size);
     memset(s_prefix_file,    '\0', g_klog_state.prefix_file_size);
     memset(s_prefix_console, '\0', g_klog_state.prefix_console_size);
 
@@ -437,9 +437,9 @@ void klog_log(
     }
 
     /* Update the index into our ring buffer */
-    g_klog_state.prefix_element_index = g_klog_state.prefix_element_index + 1;
-    if (g_klog_state.prefix_element_index >= g_klog_state.prefix_element_count) {
-        g_klog_state.prefix_element_index = 0;
+    g_klog_state.message_element_idx = g_klog_state.message_element_idx + 1;
+    if (g_klog_state.message_element_idx >= g_klog_state.message_element_count) {
+        g_klog_state.message_element_idx = 0;
     }
 
     /* Clear the buffer for the next time it is used */

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -159,6 +159,7 @@ void klog_initialize(
         g_klog_config.alloc.alloc_cb
     );
 
+# if true
     g_klog_state.message_formatted_max_size = g_klog_config.format.message_max_length;
     g_klog_state.b_messages_formatted       = klog_initialize_buffer(
         g_klog_state.message_element_count,
@@ -167,6 +168,16 @@ void klog_initialize(
         true,
         g_klog_config.alloc.alloc_cb
     );
+# else
+    g_klog_state.message_formatted_max_size = g_klog_config.format.message_max_length + 1; /* Account for null termination */
+    g_klog_state.b_messages_formatted       = klog_initialize_buffer(
+        g_klog_state.message_element_count,
+        g_klog_state.message_formatted_max_size, /* Each message slot is null terminated */
+        '\0',
+        false,
+        g_klog_config.alloc.alloc_cb
+    );
+# endif
 
     g_klog_state.p_file = klog_initialize_file(p_klog_file_info, g_klog_config.alloc.alloc_cb);
     kdprintf("p_file: %p\n",             (void*)g_klog_state.p_file);
@@ -356,7 +367,7 @@ void klog_log(
     memset(s_prefix_time, '\0', g_klog_state.prefix_time_size);
     const KlogString packed_time = g_klog_config.format.use_timestamp ? klog_format_time(s_prefix_time) : (KlogString) { 0, NULL };
 
-    /* Create the input string with the arguments injected */
+    /* Create the input string with the arguments injected - including space for null termination */
     char* s_message_formatted = g_klog_state.b_messages_formatted
         + (g_klog_state.message_element_idx * g_klog_state.message_formatted_max_size);
     va_list p_args;
@@ -442,7 +453,13 @@ void klog_log(
         g_klog_state.message_element_idx = 0;
     }
 
-    /* Clear the buffer for the next time it is used */
+    /* Clear the buffer for the next time it is used - we also re-set the null terminator at the end of the actual message */
+    printf(
+        "!!!!!!!!Clearing buffer starting %p through %p (%d bytes)\n",
+        s_message_formatted,
+        s_message_formatted + g_klog_state.message_formatted_max_size,
+        g_klog_state.message_formatted_max_size
+    );
     memset(s_message_formatted, 0, g_klog_state.message_formatted_max_size);
 #endif
 }

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -159,16 +159,6 @@ void klog_initialize(
         g_klog_config.alloc.alloc_cb
     );
 
-# if true
-    g_klog_state.message_formatted_max_size = g_klog_config.format.message_max_length;
-    g_klog_state.b_messages_formatted       = klog_initialize_buffer(
-        g_klog_state.message_element_count,
-        g_klog_state.message_formatted_max_size,
-        '\0',
-        true,
-        g_klog_config.alloc.alloc_cb
-    );
-# else
     g_klog_state.message_formatted_max_size = g_klog_config.format.message_max_length + 1; /* Account for null termination */
     g_klog_state.b_messages_formatted       = klog_initialize_buffer(
         g_klog_state.message_element_count,
@@ -177,7 +167,6 @@ void klog_initialize(
         false,
         g_klog_config.alloc.alloc_cb
     );
-# endif
 
     g_klog_state.p_file = klog_initialize_file(p_klog_file_info, g_klog_config.alloc.alloc_cb);
     kdprintf("p_file: %p\n",             (void*)g_klog_state.p_file);
@@ -454,12 +443,6 @@ void klog_log(
     }
 
     /* Clear the buffer for the next time it is used - we also re-set the null terminator at the end of the actual message */
-    printf(
-        "!!!!!!!!Clearing buffer starting %p through %p (%d bytes)\n",
-        s_message_formatted,
-        s_message_formatted + g_klog_state.message_formatted_max_size,
-        g_klog_state.message_formatted_max_size
-    );
     memset(s_message_formatted, 0, g_klog_state.message_formatted_max_size);
 #endif
 }

--- a/src/klog/klog_format.c
+++ b/src/klog/klog_format.c
@@ -40,6 +40,18 @@ uint32_t klog_format_prefix_length_get(
     return total;
 }
 
+/**
+ * @todo Instead of taking the allocation callback and allocating space for the sanitized version,
+ *      we need to take the output buffer (and its size) via parameter, and just iterate over the
+ *      input s_name parameter and sanitize while we manually copy into the ouptut buffer.
+ *
+ *      This will require a small rethink about how we want to do the file name formatting function
+ *      as it invokes this one. We will probably just need to allocate in that function, then pass
+ *      the newly allocated buffer to this function.
+ *
+ *      We should probably also rename this function to klog_format_sanitize_whitespace or something
+ *      of the sort to denote that it isn't just for logger names.
+ */
 const char* klog_format_logger_name(
     const char* const s_name,
     void* (* const    alloc_cb)(

--- a/src/klog/klog_format.c
+++ b/src/klog/klog_format.c
@@ -179,25 +179,20 @@ uint32_t klog_format_input_message(
     const char* const s_format,
     va_list           p_args
 ) {
-    /**
-     * We need to make a copy of the args (for the second vsnprintf call) before we consume them with the first vsnprintf call
-     *
-     * NOTE THAT va_copy, va_start MAY HEAP ALLOCATE, AND va_end MAY FREE THE MEMORY DEPENDING ON THE IMPLEMENTATION - SAD
-     */
+    if (size_output == 0) {
+        kdprintf("Trying to format input message with an input buffer of size 0, must be at least 1 byte\n");
+        exit(KLOG_EXIT_CODE);
+    }
+
     va_list p_args_copy;
     va_copy(p_args_copy, p_args);
 
-    /* Calculate the length of the input message */
-    /* +1 for null termination */
-    /* @todo kjk 2026/01/14 Use _vscprintf */
-    const int32_t  input_message_length  = vsnprintf(0, 0, s_format, p_args) + 1;
-    const uint32_t actual_message_length = size_output < (uint32_t)input_message_length ? size_output + 1 : (uint32_t)input_message_length;
+    const int32_t  desired_length   = vsnprintf(b_output, size_output, s_format, p_args_copy) + 1;
+    const uint32_t resulting_length = (uint32_t)desired_length < size_output ? (uint32_t)desired_length : size_output;
 
-    /*  Format the input message with the unused copy of the args */
-    vsnprintf(b_output, actual_message_length, s_format, p_args_copy);
     va_end(p_args_copy);
 
-    return actual_message_length;
+    return resulting_length;
 }
 
 KlogString klog_format_time(

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -38,8 +38,8 @@ extern struct KlogState {
     char* b_level_strings;
     char* b_level_strings_colored;
 
-    uint32_t prefix_element_index;
-    uint32_t prefix_element_count;
+    uint32_t prefix_element_index; /* @todo rename to denote this is used for messages as well */
+    uint32_t prefix_element_count; /* @todo rename to denote this is used for messages as well */
     uint32_t prefix_file_size;
     char*    b_prefixes_file;
     uint32_t prefix_console_size;
@@ -50,7 +50,7 @@ extern struct KlogState {
     char*    b_prefixes_source_location;
 
     uint32_t message_formatted_max_size;
-    char*    b_message_formatted;
+    char*    b_messages_formatted;
 
     FILE* p_file;
 

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -38,8 +38,9 @@ extern struct KlogState {
     char* b_level_strings;
     char* b_level_strings_colored;
 
-    uint32_t prefix_element_index; /* @todo rename to denote this is used for messages as well */
-    uint32_t prefix_element_count; /* @todo rename to denote this is used for messages as well */
+    uint32_t message_element_idx;
+    uint32_t message_element_count;
+
     uint32_t prefix_file_size;
     char*    b_prefixes_file;
     uint32_t prefix_console_size;

--- a/src/klog/ut/ut-klog_format_input_message.c
+++ b/src/klog/ut/ut-klog_format_input_message.c
@@ -42,12 +42,13 @@ void print_buffer(
 
 int real_input_zero_length() {
     const uint32_t size_input  = 10;
-    const uint32_t size_output = 0;
+    const uint32_t size_output = 1;
+    const uint32_t size_malloc = size_input + 1;
 
     const char* s_format = "%s";
     const char* s_input  = "0123456789";
-    char*       b_output = malloc(size_input + 1);
-    memset(b_output, 'A', size_input);
+    char*       b_output = malloc(size_malloc);
+    memset(b_output, 'A', size_malloc);
 
     printf("Freshly memset-ed buffer:\n");
     print_buffer(b_output, size_input);
@@ -55,7 +56,7 @@ int real_input_zero_length() {
     const uint32_t result = wrapper(b_output, size_output, s_format, s_input);
 
     printf("Freshly formatted buffer:\n");
-    print_buffer(b_output, size_input);
+    print_buffer(b_output, size_malloc);
 
     if (result != 1) {
         printf("Error in real_input_zero_length(): resulting length is %d, should be 1\n", result);
@@ -69,9 +70,9 @@ int real_input_zero_length() {
         return 1;
     }
 
-    for (uint32_t idx_char = 1; idx_char < size_input; ++idx_char) {
+    for (uint32_t idx_char = 1; idx_char < size_malloc; ++idx_char) {
         if (b_output[idx_char] != 'A') {
-            printf("Error in real_input_zero_length(): Character at index %d should be A\n", idx_char);
+            printf("Error in real_input_zero_length(): Character at index %d should be 'A' but is '%c'\n", idx_char, b_output[idx_char]);
             free(b_output);
             return 1;
         }
@@ -84,20 +85,21 @@ int real_input_zero_length() {
 
 int empty_input_zero_length() {
     const uint32_t size_input  = 0;
-    const uint32_t size_output = 0;
+    const uint32_t size_output = 1;
+    const uint32_t size_malloc = size_input + 1;
 
     const char* s_format = "%s";
     const char* s_input  = "";
-    char*       b_output = malloc(size_input + 1);
-    memset(b_output, 'A', size_input);
+    char*       b_output = malloc(size_malloc);
+    memset(b_output, 'A', size_malloc);
 
     printf("Freshly memset-ed buffer:\n");
-    print_buffer(b_output, size_input);
+    print_buffer(b_output, size_malloc);
 
     const uint32_t result = wrapper(b_output, size_output, s_format, s_input);
 
     printf("Freshly formatted buffer:\n");
-    print_buffer(b_output, size_input);
+    print_buffer(b_output, size_malloc);
 
     if (result != 1) {
         printf("Error in empty_input_zero_length(): resulting length is %d, should be 1\n", result);
@@ -111,14 +113,6 @@ int empty_input_zero_length() {
         return 1;
     }
 
-    for (uint32_t idx_char = 1; idx_char < size_input; ++idx_char) {
-        if (b_output[idx_char] != 'A') {
-            printf("Error in real_input_zero_length(): Character at index %d should be A\n", idx_char);
-            free(b_output);
-            return 1;
-        }
-    }
-
     free(b_output);
 
     return 0;
@@ -127,21 +121,22 @@ int empty_input_zero_length() {
 int empty_input_real_length() {
     const uint32_t size_input  = 0;
     const uint32_t size_output = 10;
+    const uint32_t size_malloc = size_output;
 
     const char* s_format = "%s";
     const char* s_input  = "";
-    char*       b_output = malloc(size_input + 1);
-    memset(b_output, 'A', size_input + 1);
+    char*       b_output = malloc(size_malloc);
+    memset(b_output, 'A', size_malloc);
 
     printf("Freshly memset-ed buffer:\n");
-    print_buffer(b_output, size_input + 1);
+    print_buffer(b_output, size_malloc);
 
     const uint32_t result = wrapper(b_output, size_output, s_format, s_input);
 
     printf("Freshly formatted buffer:\n");
-    print_buffer(b_output, size_input + 1);
+    print_buffer(b_output, size_malloc);
 
-    if (result != size_input + 1) {
+    if (result != 1) {
         printf("Error in empty_input_real_length(): resulting length is %d, should be %d\n", result, size_input + 1);
         free(b_output);
         return 1;
@@ -153,6 +148,14 @@ int empty_input_real_length() {
         return 1;
     }
 
+    for (uint32_t idx_char = 1; idx_char < size_malloc; ++idx_char) {
+        if (b_output[idx_char] != 'A') {
+            printf("Error in empty_input_real_length(): Character at index %d should be 'A' but is '%c'\n", idx_char, b_output[idx_char]);
+            free(b_output);
+            return 1;
+        }
+    }
+
     free(b_output);
 
     return 0;
@@ -161,19 +164,20 @@ int empty_input_real_length() {
 int shorter_input() {
     const uint32_t size_input  = 5;
     const uint32_t size_output = 10;
+    const uint32_t size_malloc = size_input + 1;
 
     const char* s_format = "%s";
     const char* s_input  = "01234";
     char*       b_output = malloc(size_input + 1);
-    memset(b_output, 'A', size_input + 1);
+    memset(b_output, 'A', size_malloc);
 
     printf("Freshly memset-ed buffer:\n");
-    print_buffer(b_output, size_input + 1);
+    print_buffer(b_output, size_malloc);
 
     const uint32_t result = wrapper(b_output, size_output, s_format, s_input);
 
     printf("Freshly formatted buffer:\n");
-    print_buffer(b_output, size_input + 1);
+    print_buffer(b_output, size_malloc);
 
     if (result != size_input + 1) {
         printf("Error in shorter_input(): resulting length is %d, should be %d\n", result, size_input + 1);
@@ -201,6 +205,14 @@ int shorter_input() {
         }
     }
 
+    for (uint32_t idx_char = result; idx_char < size_malloc; ++idx_char) {
+        if (b_output[idx_char] != 'A') {
+            printf("Error in shorter_input(): Character at index %d should be 'A' but is '%c'\n", idx_char, b_output[idx_char]);
+            free(b_output);
+            return 1;
+        }
+    }
+
     free(b_output);
 
     return 0;
@@ -209,21 +221,22 @@ int shorter_input() {
 int shorter_input_off_by_one() {
     const uint32_t size_input  = 9;
     const uint32_t size_output = 10;
+    const uint32_t size_malloc = size_output;
 
     const char* s_format = "%s";
     const char* s_input  = "012345678";
-    char*       b_output = malloc(size_input + 1);
-    memset(b_output, 'A', size_input + 1);
+    char*       b_output = malloc(size_malloc);
+    memset(b_output, 'A', size_malloc);
 
     printf("Freshly memset-ed buffer:\n");
-    print_buffer(b_output, size_input + 1);
+    print_buffer(b_output, size_malloc);
 
     const uint32_t result = wrapper(b_output, size_output, s_format, s_input);
 
     printf("Freshly formatted buffer:\n");
-    print_buffer(b_output, size_input + 1);
+    print_buffer(b_output, size_malloc);
 
-    if (result != size_input + 1) {
+    if (result != size_output) {
         printf("Error in shorter_input_off_by_one(): resulting length is %d, should be %d\n", result, size_input + 1);
         free(b_output);
         return 1;
@@ -236,7 +249,7 @@ int shorter_input_off_by_one() {
     }
 
     const char* s_expected = "012345678";
-    for (uint32_t idx_char = 0; idx_char < result; ++idx_char) {
+    for (uint32_t idx_char = 0; idx_char < size_input; ++idx_char) {
         if (b_output[idx_char] != s_expected[idx_char]) {
             printf(
                 "Error in shorter_input_off_by_one(): Character at index %d is '%c', should be '%c'\n",
@@ -256,35 +269,36 @@ int shorter_input_off_by_one() {
 
 int exact_length_input() {
     const uint32_t size_input  = 10;
-    const uint32_t size_output = 10;
+    const uint32_t size_output = size_input;
+    const uint32_t size_malloc = size_output;
 
     const char* s_format = "%s";
     const char* s_input  = "0123456789";
-    char*       b_output = malloc(size_input + 1);
-    memset(b_output, 'A', size_input + 1);
+    char*       b_output = malloc(size_malloc);
+    memset(b_output, 'A', size_malloc);
 
     printf("Freshly memset-ed buffer:\n");
-    print_buffer(b_output, size_input + 1);
+    print_buffer(b_output, size_malloc);
 
     const uint32_t result = wrapper(b_output, size_output, s_format, s_input);
 
     printf("Freshly formatted buffer:\n");
-    print_buffer(b_output, size_input + 1);
+    print_buffer(b_output, size_malloc);
 
-    if (result != size_input + 1) {
+    if (result != size_input) {
         printf("Error in exact_length_input(): resulting length is %d, should be %d\n", result, size_input + 1);
         free(b_output);
         return 1;
     }
 
-    if (b_output[size_input] != '\0') {
+    if (b_output[size_input - 1] != '\0') {
         printf("Error in exact_length_input(): Character at index %d should be null terminator\n", size_input);
         free(b_output);
         return 1;
     }
 
     const char* s_expected = "0123456789";
-    for (uint32_t idx_char = 0; idx_char < result; ++idx_char) {
+    for (uint32_t idx_char = 0; idx_char < result - 1; ++idx_char) {
         if (b_output[idx_char] != s_expected[idx_char]) {
             printf(
                 "Error in exact_length_input(): Character at index %d is '%c', should be '%c'\n",
@@ -305,37 +319,39 @@ int exact_length_input() {
 int longer_input() {
     const uint32_t size_input  = 20;
     const uint32_t size_output = 10;
+    const uint32_t size_malloc = size_input;
 
     const char* s_format = "%s";
     /*                 00 + 0123456789            */
     /*                 10 +           0123456789  */
     /*                 20 +                     0 */
     const char* s_input  = "0123456789ABCDEFGHIJK";
-    char*       b_output = malloc(size_input + 1);
-    memset(b_output, 'A', size_input + 1);
+    char*       b_output = malloc(size_malloc);
+    memset(b_output, 'A', size_malloc);
 
     printf("Freshly memset-ed buffer:\n");
-    print_buffer(b_output, size_input + 1);
+    print_buffer(b_output, size_malloc);
 
     const uint32_t result = wrapper(b_output, size_output, s_format, s_input);
 
     printf("Freshly formatted buffer:\n");
-    print_buffer(b_output, size_input + 1);
+    print_buffer(b_output, size_malloc);
 
-    if (result != size_output + 1) {
-        printf("Error in longer_input(): resulting length is %d, should be %d\n", result, size_output + 1);
+    if (result != size_output) {
+        printf("Error in longer_input(): resulting length is %d, should be %d\n", result, size_output);
         free(b_output);
         return 1;
     }
 
-    if (b_output[size_output] != '\0') {
+    if (b_output[size_output - 1] != '\0') {
         printf("Error in longer_input(): Character at index %d should be null terminator\n", size_output);
         free(b_output);
         return 1;
     }
 
-    const char* s_expected = "0123456789";
-    for (uint32_t idx_char = 0; idx_char < result; ++idx_char) {
+    /* Check all formatted characters (up until the null terminator) */
+    const char* s_expected = "012345678";
+    for (uint32_t idx_char = 0; idx_char < result - 1; ++idx_char) {
         if (b_output[idx_char] != s_expected[idx_char]) {
             printf(
                 "Error in longer_input(): Character at index %d is '%c', should be '%c'\n",
@@ -349,10 +365,10 @@ int longer_input() {
     }
 
     /* Ensure the non-populated characters are as we set them (all As) */
-    for (uint32_t idx_char = result + 1; idx_char < size_input + 1; ++idx_char) {
+    for (uint32_t idx_char = result; idx_char < size_malloc; ++idx_char) {
         if (b_output[idx_char] != 'A') {
             printf(
-                "Error in interesting_format(): Character at index %d is '%c', should be 'A'\n",
+                "Error in longer_input(): Character at index %d is '%c', should be 'A'\n",
                 idx_char,
                 b_output[idx_char]
             );
@@ -369,34 +385,35 @@ int longer_input() {
 int interesting_format() {
     const uint32_t size_input  = 15;
     const uint32_t size_output = 10;
+    const uint32_t size_malloc = size_input;
 
     const char* s_format = "%02d %07X";
-    char*       b_output = malloc(size_input + 1);
-    memset(b_output, 'A', size_input + 1);
+    char*       b_output = malloc(size_malloc);
+    memset(b_output, 'A', size_malloc);
 
     printf("Freshly memset-ed buffer:\n");
-    print_buffer(b_output, size_input + 1);
+    print_buffer(b_output, size_malloc);
 
     const uint32_t result = wrapper(b_output, size_output, s_format, 7, 912081); /* 912081 is 0xDEAD1 */
 
     printf("Freshly formatted buffer:\n");
-    print_buffer(b_output, size_input + 1);
+    print_buffer(b_output, size_malloc);
 
-    if (result != size_output + 1) {
+    if (result != size_output) {
         printf("Error in interesting_format(): resulting length is %d, should be %d\n", result, size_output + 1);
         free(b_output);
         return 1;
     }
 
-    if (b_output[size_output] != '\0') {
-        printf("Error in interesting_format(): Character at index %d should be null terminator\n", size_output);
+    if (b_output[size_output - 1] != '\0') {
+        printf("Error in interesting_format(): Character at index %d should be null terminator\n", size_output - 1);
         free(b_output);
         return 1;
     }
 
     /* Ensure the formatted bit is correct */
     const char* s_expected = "07 00DEAD1";
-    for (uint32_t idx_char = 0; idx_char < result; ++idx_char) {
+    for (uint32_t idx_char = 0; idx_char < result - 1; ++idx_char) {
         if (b_output[idx_char] != s_expected[idx_char]) {
             printf(
                 "Error in interesting_format(): Character at index %d is '%c', should be '%c'\n",
@@ -410,7 +427,7 @@ int interesting_format() {
     }
 
     /* Ensure the non-populated characters are as we set them (all As) */
-    for (uint32_t idx_char = result + 1; idx_char < size_input + 1; ++idx_char) {
+    for (uint32_t idx_char = result; idx_char < size_malloc; ++idx_char) {
         if (b_output[idx_char] != 'A') {
             printf(
                 "Error in interesting_format(): Character at index %d is '%c', should be 'A'\n",

--- a/src/klog/ut/ut-klog_prefix_buffer_usage.c
+++ b/src/klog/ut/ut-klog_prefix_buffer_usage.c
@@ -15,12 +15,12 @@ int no_async_param(
     KlogConsoleInfo console_info       = { KLOG_LEVEL_TRACE, false };
     klog_initialize(5, format_info, NULL, &console_info, NULL, NULL);
 
-    if (g_klog_state.prefix_element_index != 0) {
+    if (g_klog_state.message_element_idx != 0) {
         printf("Klog prefix element index should be 0 before anything is logged\n");
         return 1;
     }
 
-    if (g_klog_state.prefix_element_count != 1) {
+    if (g_klog_state.message_element_count != 1) {
         printf("Klog prefix element count should be 1 if no async parameter is provided\n");
         return 1;
     }
@@ -58,7 +58,7 @@ int no_async_param(
     klog_logger_level_set(p, KLOG_LEVEL_INFO);
     klog_info(p, "test");
 
-    if (g_klog_state.prefix_element_index != 0) {
+    if (g_klog_state.message_element_idx != 0) {
         printf("Klog prefix element index should still be 0 because the buffer only has 1 element\n");
         return 1;
     }
@@ -97,12 +97,12 @@ int single_element(
     KlogConsoleInfo console_info       = { KLOG_LEVEL_INFO, false };
     klog_initialize(5, format_info, &async_info, &console_info, NULL, NULL);
 
-    if (g_klog_state.prefix_element_index != 0) {
+    if (g_klog_state.message_element_idx != 0) {
         printf("Klog prefix element index should be 0 before anything is logged\n");
         return 1;
     }
 
-    if (g_klog_state.prefix_element_count != 1) {
+    if (g_klog_state.message_element_count != 1) {
         printf("Klog prefix element count should be 1 if only 1 queue element is specified\n");
         return 1;
     }
@@ -140,7 +140,7 @@ int single_element(
     klog_logger_level_set(p, KLOG_LEVEL_INFO);
     klog_info(p, "test");
 
-    if (g_klog_state.prefix_element_index != 0) {
+    if (g_klog_state.message_element_idx != 0) {
         printf("Klog prefix element index should still be 0 because the buffer only has 1 element\n");
         return 1;
     }
@@ -181,13 +181,13 @@ int multiple_elements(
     KlogConsoleInfo console_info       = { KLOG_LEVEL_DEBUG, false };
     klog_initialize(num_loggers, format_info, &async_info, &console_info, NULL, NULL);
 
-    if (g_klog_state.prefix_element_index != 0) {
+    if (g_klog_state.message_element_idx != 0) {
         printf("Klog prefix element index should be 0 before anything is logged\n");
         return 1;
     }
 
-    if (g_klog_state.prefix_element_count != num_elements) {
-        printf("Klog prefix element count should be %d, but is %d\n", num_elements, g_klog_state.prefix_element_count);
+    if (g_klog_state.message_element_count != num_elements) {
+        printf("Klog prefix element count should be %d, but is %d\n", num_elements, g_klog_state.message_element_count);
         return 1;
     }
 
@@ -227,7 +227,7 @@ int multiple_elements(
     klog_logger_level_set(p, KLOG_LEVEL_INFO);
     klog_info(p, "test");
 
-    if (g_klog_state.prefix_element_index != 1) {
+    if (g_klog_state.message_element_idx != 1) {
         printf("Klog prefix element index should be 1 after the first log\n");
         return 1;
     }
@@ -266,7 +266,7 @@ int multiple_elements(
     klog_trace(p2, "this won't get logged due to the console's min level at debug, and no file logger");
     klog_debug(p2, "test number 2");
 
-    if (g_klog_state.prefix_element_index != 2) {
+    if (g_klog_state.message_element_idx != 2) {
         printf("Klog prefix element index should be 2 after the second log\n");
         return 1;
     }
@@ -305,7 +305,7 @@ int multiple_elements(
     klog_info(p3, "this won't get logged due to the logger's level");
     klog_error(p3, "test 3");
 
-    if (g_klog_state.prefix_element_index != 0) {
+    if (g_klog_state.message_element_idx != 0) {
         printf("Klog prefix element index should be 0 after the third log due to overflow\n");
         return 1;
     }
@@ -349,7 +349,7 @@ int multiple_elements(
 
     klog_info(p, "test, again!");
 
-    if (g_klog_state.prefix_element_index != 1) {
+    if (g_klog_state.message_element_idx != 1) {
         printf("Klog prefix element index should be 1 after the first log\n");
         return 1;
     }

--- a/src/klog/ut/ut-klog_prefix_buffer_usage.c
+++ b/src/klog/ut/ut-klog_prefix_buffer_usage.c
@@ -528,6 +528,8 @@ int main(
     void
 ) {
     /* int result = no_async_param() || single_element() || multiple_elements() || noop(); */
+    /* int result = no_async_param(); */
+    /* int result = single_element(); */
     int result = multiple_elements();
 
     return result;

--- a/src/klog/ut/ut-klog_prefix_buffer_usage.c
+++ b/src/klog/ut/ut-klog_prefix_buffer_usage.c
@@ -11,17 +11,18 @@ int no_async_param(
     void
 ) {
     const uint32_t  logger_name_length = 6;
-    KlogFormatInfo  format_info        = { logger_name_length, 10, 0, false, false };
+    const uint32_t  message_max_length = 7;
+    KlogFormatInfo  format_info        = { logger_name_length, message_max_length, 0, false, false };
     KlogConsoleInfo console_info       = { KLOG_LEVEL_TRACE, false };
     klog_initialize(5, format_info, NULL, &console_info, NULL, NULL);
 
     if (g_klog_state.message_element_idx != 0) {
-        printf("Klog prefix element index should be 0 before anything is logged\n");
+        printf("Klog message element index should be 0 before anything is logged\n");
         return 1;
     }
 
     if (g_klog_state.message_element_count != 1) {
-        printf("Klog prefix element count should be 1 if no async parameter is provided\n");
+        printf("Klog message element count should be 1 if no async parameter is provided\n");
         return 1;
     }
 
@@ -35,8 +36,13 @@ int no_async_param(
         return 1;
     }
 
-    char* empty_buffer = malloc(prefix_size);
-    memset(empty_buffer, 0, prefix_size);
+    if (g_klog_state.message_formatted_max_size != message_max_length) {
+        printf("Klog message max length should be %d but it is %d\n", message_max_length, g_klog_state.message_formatted_max_size);
+        return 1;
+    }
+
+    char* empty_prefix_buffer = malloc(prefix_size);
+    memset(empty_prefix_buffer, 0, prefix_size);
     if (g_klog_state.b_prefixes_file == NULL) {
         printf("Klog file prefix buffer is not initialized\n");
         return 1;
@@ -45,12 +51,23 @@ int no_async_param(
         printf("Klog console prefix buffer is not initialized\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_file, empty_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file, empty_prefix_buffer, prefix_size)) {
         printf("Klog file prefix buffer should be all null characters but it is not\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, empty_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, empty_prefix_buffer, prefix_size)) {
         printf("Klog console prefix buffer should be all null characters but it is not\n");
+        return 1;
+    }
+
+    char* empty_message_buffer = malloc(message_max_length);
+    memset(empty_message_buffer, 0, message_max_length);
+    if (g_klog_state.b_messages_formatted == NULL) {
+        printf("Klog formatted message buffer is not initialized\n");
+        return 1;
+    }
+    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer, message_max_length)) {
+        printf("Klog formatted messages buffer should be all null characters but it is not\n");
         return 1;
     }
 
@@ -59,29 +76,30 @@ int no_async_param(
     klog_info(p, "test");
 
     if (g_klog_state.message_element_idx != 0) {
-        printf("Klog prefix element index should still be 0 because the buffer only has 1 element\n");
+        printf("Klog message element index should still be 0 because the buffer only has 1 element\n");
         return 1;
     }
 
-    char* full_buffer = "[dummy!] [info ] ";
-    if (memcmp(g_klog_state.b_prefixes_file, full_buffer, prefix_size)) {
+    char* full_prefix_buffer = "[dummy!] [info ] ";
+    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer, prefix_size)) {
         printf(
             "Klog file prefix buffer should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
-            full_buffer,
+            full_prefix_buffer,
             g_klog_state.b_prefixes_file
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, full_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer, prefix_size)) {
         printf(
             "Klog console prefix buffer should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
-            full_buffer,
+            full_prefix_buffer,
             g_klog_state.b_prefixes_console
         );
         return 1;
     }
 
-    free(empty_buffer);
+    free(empty_prefix_buffer);
+    free(empty_message_buffer);
 
     klog_deinitialize();
 
@@ -92,18 +110,20 @@ int single_element(
     void
 ) {
     const uint32_t  logger_name_length = 8;
-    KlogFormatInfo  format_info        = { logger_name_length, 10, 0, false, false };
-    KlogAsyncInfo   async_info         = { 1, 3 };
+    const uint32_t  message_max_length = 11;
+    const uint32_t  num_elements       = 1;
+    KlogFormatInfo  format_info        = { logger_name_length, message_max_length, 0, false, false };
+    KlogAsyncInfo   async_info         = { num_elements, 3 };
     KlogConsoleInfo console_info       = { KLOG_LEVEL_INFO, false };
     klog_initialize(5, format_info, &async_info, &console_info, NULL, NULL);
 
     if (g_klog_state.message_element_idx != 0) {
-        printf("Klog prefix element index should be 0 before anything is logged\n");
+        printf("Klog message element index should be 0 before anything is logged\n");
         return 1;
     }
 
     if (g_klog_state.message_element_count != 1) {
-        printf("Klog prefix element count should be 1 if only 1 queue element is specified\n");
+        printf("Klog message element count should be 1 if only 1 queue element is specified\n");
         return 1;
     }
 
@@ -117,8 +137,13 @@ int single_element(
         return 1;
     }
 
-    char* empty_buffer = malloc(prefix_size);
-    memset(empty_buffer, 0, prefix_size);
+    if (g_klog_state.message_formatted_max_size != message_max_length) {
+        printf("Klog message max length should be %d but it is %d\n", message_max_length, g_klog_state.message_formatted_max_size);
+        return 1;
+    }
+
+    char* empty_prefix_buffer = malloc(prefix_size);
+    memset(empty_prefix_buffer, 0, prefix_size);
     if (g_klog_state.b_prefixes_file == NULL) {
         printf("Klog file prefix buffer is not initialized\n");
         return 1;
@@ -127,12 +152,23 @@ int single_element(
         printf("Klog console prefix buffer is not initialized\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_file, empty_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file, empty_prefix_buffer, prefix_size)) {
         printf("Klog file prefix buffer should be all null characters but it is not\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, empty_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, empty_prefix_buffer, prefix_size)) {
         printf("Klog console prefix buffer should be all null characters but it is not\n");
+        return 1;
+    }
+
+    char* empty_message_buffer = malloc(message_max_length);
+    memset(empty_message_buffer, 0, message_max_length);
+    if (g_klog_state.b_messages_formatted == NULL) {
+        printf("Klog formatted message buffer is not initialized\n");
+        return 1;
+    }
+    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer, message_max_length)) {
+        printf("Klog formatted messages buffer should be all null characters but it is not\n");
         return 1;
     }
 
@@ -141,29 +177,30 @@ int single_element(
     klog_info(p, "test");
 
     if (g_klog_state.message_element_idx != 0) {
-        printf("Klog prefix element index should still be 0 because the buffer only has 1 element\n");
+        printf("Klog message element index should still be 0 because the buffer only has 1 element\n");
         return 1;
     }
 
-    char* full_buffer = "[dummy123] [info ] ";
-    if (memcmp(g_klog_state.b_prefixes_file, full_buffer, prefix_size)) {
+    char* full_prefix_buffer = "[dummy123] [info ] ";
+    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer, prefix_size)) {
         printf(
             "Klog file prefix buffer should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
-            full_buffer,
+            full_prefix_buffer,
             g_klog_state.b_prefixes_file
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, full_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer, prefix_size)) {
         printf(
             "Klog console prefix buffer should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
-            full_buffer,
+            full_prefix_buffer,
             g_klog_state.b_prefixes_console
         );
         return 1;
     }
 
-    free(empty_buffer);
+    free(empty_prefix_buffer);
+    free(empty_message_buffer);
 
     klog_deinitialize();
 
@@ -173,21 +210,22 @@ int single_element(
 int multiple_elements(
     void
 ) {
-    const uint32_t  num_elements       = 3;
     const uint32_t  num_loggers        = 4;
     const uint32_t  logger_name_length = 3;
-    KlogFormatInfo  format_info        = { logger_name_length, 10, 0, false, false };
+    const uint32_t  message_max_length = 7; /* good length to set manually if needed */
+    const uint32_t  num_elements       = 3;
+    KlogFormatInfo  format_info        = { logger_name_length, message_max_length, 0, false, false };
     KlogAsyncInfo   async_info         = { num_elements, 3 };
     KlogConsoleInfo console_info       = { KLOG_LEVEL_DEBUG, false };
     klog_initialize(num_loggers, format_info, &async_info, &console_info, NULL, NULL);
 
     if (g_klog_state.message_element_idx != 0) {
-        printf("Klog prefix element index should be 0 before anything is logged\n");
+        printf("Klog message element index should be 0 before anything is logged\n");
         return 1;
     }
 
     if (g_klog_state.message_element_count != num_elements) {
-        printf("Klog prefix element count should be %d, but is %d\n", num_elements, g_klog_state.message_element_count);
+        printf("Klog message element count should be %d, but is %d\n", num_elements, g_klog_state.message_element_count);
         return 1;
     }
 
@@ -201,8 +239,13 @@ int multiple_elements(
         return 1;
     }
 
-    char* empty_buffer = malloc(prefix_size);
-    memset(empty_buffer, 0, prefix_size);
+    if (g_klog_state.message_formatted_max_size != message_max_length) {
+        printf("Klog message max length should be %d but it is %d\n", message_max_length, g_klog_state.message_formatted_max_size);
+        return 1;
+    }
+
+    char* empty_prefix_buffer_all = malloc(prefix_size * num_elements);
+    memset(empty_prefix_buffer_all, 0, prefix_size * num_elements);
     if (g_klog_state.b_prefixes_file == NULL) {
         printf("Klog file prefix buffer is not initialized\n");
         return 1;
@@ -211,52 +254,133 @@ int multiple_elements(
         printf("Klog console prefix buffer is not initialized\n");
         return 1;
     }
+    if (memcmp(g_klog_state.b_prefixes_file, empty_prefix_buffer_all, prefix_size * num_elements)) {
+        printf("Klog file prefix buffer should be all null characters but it is not\n");
+        return 1;
+    }
+    if (memcmp(g_klog_state.b_prefixes_console, empty_prefix_buffer_all, prefix_size * num_elements)) {
+        printf("Klog console prefix buffer should be all null characters but it is not\n");
+        return 1;
+    }
+
+    char* empty_message_buffer_all = malloc(message_max_length * num_elements);
+    memset(empty_message_buffer_all, 0, message_max_length * num_elements);
+    if (g_klog_state.b_messages_formatted == NULL) {
+        printf("Klog formatted message buffer is not initialized\n");
+        return 1;
+    }
+    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer_all, message_max_length * num_elements)) {
+        printf("Klog formatted messages buffer should be all null characters but it is not\n");
+        return 1;
+    }
+
+    char* dirty_message_buffer_all = malloc(message_max_length * num_elements);
+    memset(dirty_message_buffer_all, 'K', message_max_length * num_elements);
+    memcpy(g_klog_state.b_messages_formatted, dirty_message_buffer_all, message_max_length * num_elements); /* Dirty all message buffers to validate clear logic */
+    if (memcmp(g_klog_state.b_messages_formatted, dirty_message_buffer_all, message_max_length * num_elements)) {
+        printf("Klog formatted messages buffer should be all dirty characters but it is not\n");
+        return 1;
+    }
 
     /* First logging statement */
 
-    if (memcmp(g_klog_state.b_prefixes_file, empty_buffer, prefix_size)) {
+    printf("Buffer before first log:\n");
+    for (uint32_t byte_idx = 0; byte_idx < message_max_length * num_elements; ++byte_idx) {
+        const char    byte   = g_klog_state.b_messages_formatted[byte_idx];
+        const int16_t casted = (int16_t)byte;
+        printf("%d = %d\n", byte_idx, casted);
+    }
+
+    char* dirty_message_buffer = malloc(message_max_length);
+    memset(dirty_message_buffer, 'K', message_max_length);
+    if (memcmp(g_klog_state.b_messages_formatted + (message_max_length * 0), dirty_message_buffer, message_max_length)) {
+        printf(
+            "Klog formatted message buffer element 0 should be dirty ('K') before logging anything, but instead it contains \"%.*s\"\n",
+            message_max_length,
+            g_klog_state.b_messages_formatted + (message_max_length * 0)
+        );
+        return 1;
+    }
+
+    char* empty_prefix_buffer = malloc(prefix_size);
+    memset(empty_prefix_buffer, 0, prefix_size);
+    if (memcmp(g_klog_state.b_prefixes_file, empty_prefix_buffer, prefix_size)) {
         printf("Klog file prefix buffer element 0 should be all null characters but it is not\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, empty_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, empty_prefix_buffer, prefix_size)) {
         printf("Klog console prefix buffer element 0 should be all null characters but it is not\n");
         return 1;
     }
 
+    char* empty_message_buffer = malloc(message_max_length);
+    memset(empty_message_buffer, 0, message_max_length);
+
     const KlogLoggerHandle* p = klog_logger_create("dum");
     klog_logger_level_set(p, KLOG_LEVEL_INFO);
-    klog_info(p, "test");
+    klog_info(p, "1234567");
 
     if (g_klog_state.message_element_idx != 1) {
-        printf("Klog prefix element index should be 1 after the first log\n");
+        printf("Klog message element index should be 1 after the first log\n");
         return 1;
     }
 
-    char* full_buffer = "[dum] [info ] ";
-    if (memcmp(g_klog_state.b_prefixes_file, full_buffer, prefix_size)) {
+    char* full_prefix_buffer = "[dum] [info ] ";
+    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer, prefix_size)) {
         printf(
             "Klog file prefix buffer element 0 should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
-            full_buffer,
+            full_prefix_buffer,
             g_klog_state.b_prefixes_file
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, full_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer, prefix_size)) {
         printf(
             "Klog console prefix buffer element 0 should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
-            full_buffer,
+            full_prefix_buffer,
             g_klog_state.b_prefixes_console
+        );
+        return 1;
+    }
+
+    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer, message_max_length)) {
+        printf(
+            "Klog formatted message buffer element 0 should be empty (cleared) after logging at info level, but instead it contains \"%.*s\"\n",
+            message_max_length,
+            g_klog_state.b_messages_formatted
         );
         return 1;
     }
 
     /* Second logging statement */
 
-    if (memcmp(g_klog_state.b_prefixes_file + prefix_size, empty_buffer, prefix_size)) {
+    printf("Buffer after first log:\n");
+    for (uint32_t byte_idx = 0; byte_idx < message_max_length * num_elements; ++byte_idx) {
+        const char    byte   = g_klog_state.b_messages_formatted[byte_idx];
+        const int16_t casted = (int16_t)byte;
+        printf("%d = %d\n", byte_idx, casted);
+    }
+
+    printf(
+        "!!!!!!!!Checking buffer starting %p through %p (%d bytes)\n",
+        g_klog_state.b_messages_formatted + (message_max_length * 1),
+        g_klog_state.b_messages_formatted + (message_max_length * 1) + message_max_length,
+        message_max_length
+    );
+    if (memcmp(g_klog_state.b_messages_formatted + (message_max_length * 1), dirty_message_buffer, message_max_length)) {
+        printf(
+            "Klog formatted message buffer element 1 should be dirty ('K') after logging at info level 1 time, but instead it contains \"%.*s\"\n",
+            message_max_length,
+            g_klog_state.b_messages_formatted + (message_max_length * 1)
+        );
+        return 1;
+    }
+
+    if (memcmp(g_klog_state.b_prefixes_file + prefix_size, empty_prefix_buffer, prefix_size)) {
         printf("Klog file prefix buffer element 1 should be all null characters but it is not\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console + prefix_size, empty_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console + prefix_size, empty_prefix_buffer, prefix_size)) {
         printf("Klog console prefix buffer element 1 should be all null characters but it is not\n");
         return 1;
     }
@@ -267,35 +391,44 @@ int multiple_elements(
     klog_debug(p2, "test number 2");
 
     if (g_klog_state.message_element_idx != 2) {
-        printf("Klog prefix element index should be 2 after the second log\n");
+        printf("Klog message element index should be 2 after the second log\n");
         return 1;
     }
 
-    char* full_buffer_2 = "[two] [debug] ";
-    if (memcmp(g_klog_state.b_prefixes_file + prefix_size, full_buffer_2, prefix_size)) {
+    char* full_prefix_buffer_2 = "[two] [debug] ";
+    if (memcmp(g_klog_state.b_prefixes_file + prefix_size, full_prefix_buffer_2, prefix_size)) {
         printf(
             "Klog file prefix buffer element 1 should contain \"%s\" after logging at trace level, but instead it contains \"%s\"\n",
-            full_buffer_2,
+            full_prefix_buffer_2,
             g_klog_state.b_prefixes_file + prefix_size
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console + prefix_size, full_buffer_2, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console + prefix_size, full_prefix_buffer_2, prefix_size)) {
         printf(
             "Klog console prefix buffer element 1 should contain \"%s\" after logging at trace level, but instead it contains \"%s\"\n",
-            full_buffer_2,
+            full_prefix_buffer_2,
             g_klog_state.b_prefixes_console + prefix_size
+        );
+        return 1;
+    }
+
+    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer, message_max_length)) {
+        printf(
+            "Klog formatted message buffer element 1 should be empty (cleared) after logging at info level 2 times, but instead it contains \"%.*s\"\n",
+            message_max_length,
+            g_klog_state.b_messages_formatted + (message_max_length * 1)
         );
         return 1;
     }
 
     /* Third logging statement */
 
-    if (memcmp(g_klog_state.b_prefixes_file + prefix_size * 2, empty_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file + prefix_size * 2, empty_prefix_buffer, prefix_size)) {
         printf("Klog file prefix buffer element 2 should be all null characters but it is not\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console + prefix_size * 2, empty_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console + prefix_size * 2, empty_prefix_buffer, prefix_size)) {
         printf("Klog console prefix buffer element 2 should be all null characters but it is not\n");
         return 1;
     }
@@ -306,23 +439,23 @@ int multiple_elements(
     klog_error(p3, "test 3");
 
     if (g_klog_state.message_element_idx != 0) {
-        printf("Klog prefix element index should be 0 after the third log due to overflow\n");
+        printf("Klog message element index should be 0 after the third log due to overflow\n");
         return 1;
     }
 
-    char* full_buffer_3 = "[3  ] [ERROR] ";
-    if (memcmp(g_klog_state.b_prefixes_file + prefix_size * 2, full_buffer_3, prefix_size)) {
+    char* full_prefix_buffer_3 = "[3  ] [ERROR] ";
+    if (memcmp(g_klog_state.b_prefixes_file + prefix_size * 2, full_prefix_buffer_3, prefix_size)) {
         printf(
             "Klog file prefix buffer element 2 should contain \"%s\" after logging at error level, but instead it contains \"%s\"\n",
-            full_buffer_3,
+            full_prefix_buffer_3,
             g_klog_state.b_prefixes_file + prefix_size * 2
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console + prefix_size * 2, full_buffer_3, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console + prefix_size * 2, full_prefix_buffer_3, prefix_size)) {
         printf(
             "Klog console prefix buffer element 2 should contain \"%s\" after logging at error level, but instead it contains \"%s\"\n",
-            full_buffer_3,
+            full_prefix_buffer_3,
             g_klog_state.b_prefixes_console + prefix_size * 2
         );
         return 1;
@@ -330,18 +463,18 @@ int multiple_elements(
 
     /* Fourth logging statement */
 
-    if (memcmp(g_klog_state.b_prefixes_file, full_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer, prefix_size)) {
         printf(
             "Klog file prefix buffer element 0 should contain \"%s\" before logging after overflow at info level, but instead it contains \"%s\"\n",
-            full_buffer,
+            full_prefix_buffer,
             g_klog_state.b_prefixes_file
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, full_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer, prefix_size)) {
         printf(
             "Klog console prefix buffer element 0 should contain \"%s\" before logging after overflow at info level, but instead it contains \"%s\"\n",
-            full_buffer,
+            full_prefix_buffer,
             g_klog_state.b_prefixes_file
         );
         return 1;
@@ -350,22 +483,22 @@ int multiple_elements(
     klog_info(p, "test, again!");
 
     if (g_klog_state.message_element_idx != 1) {
-        printf("Klog prefix element index should be 1 after the first log\n");
+        printf("Klog message element index should be 1 after the first log\n");
         return 1;
     }
 
-    if (memcmp(g_klog_state.b_prefixes_file, full_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer, prefix_size)) {
         printf(
             "Klog file prefix buffer element 0 should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
-            full_buffer,
+            full_prefix_buffer,
             g_klog_state.b_prefixes_file
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, full_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer, prefix_size)) {
         printf(
             "Klog console prefix buffer element 0 should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
-            full_buffer,
+            full_prefix_buffer,
             g_klog_state.b_prefixes_console
         );
         return 1;
@@ -373,7 +506,12 @@ int multiple_elements(
 
     /* Clean up */
 
-    free(empty_buffer);
+    free(empty_prefix_buffer_all);
+    free(empty_prefix_buffer);
+    free(empty_message_buffer_all);
+    free(empty_message_buffer);
+    free(dirty_message_buffer_all);
+    free(dirty_message_buffer);
 
     klog_deinitialize();
 
@@ -389,8 +527,8 @@ int noop(
 int main(
     void
 ) {
-    int result = no_async_param() || single_element() || multiple_elements() || noop()
-    ;
+    /* int result = no_async_param() || single_element() || multiple_elements() || noop(); */
+    int result = multiple_elements();
 
     return result;
 }

--- a/src/klog/ut/ut-klog_prefix_buffer_usage.c
+++ b/src/klog/ut/ut-klog_prefix_buffer_usage.c
@@ -10,10 +10,11 @@
 int no_async_param(
     void
 ) {
-    const uint32_t  logger_name_length = 6;
-    const uint32_t  message_max_length = 7;
-    KlogFormatInfo  format_info        = { logger_name_length, message_max_length, 0, false, false };
-    KlogConsoleInfo console_info       = { KLOG_LEVEL_TRACE, false };
+    const uint32_t  logger_name_length          = 6;
+    const uint32_t  message_max_length          = 7;
+    const uint32_t  message_total_length_length = message_max_length + 1;
+    KlogFormatInfo  format_info                 = { logger_name_length, message_max_length, 0, false, false };
+    KlogConsoleInfo console_info                = { KLOG_LEVEL_TRACE, false };
     klog_initialize(5, format_info, NULL, &console_info, NULL, NULL);
 
     if (g_klog_state.message_element_idx != 0) {
@@ -36,8 +37,8 @@ int no_async_param(
         return 1;
     }
 
-    if (g_klog_state.message_formatted_max_size != message_max_length) {
-        printf("Klog message max length should be %d but it is %d\n", message_max_length, g_klog_state.message_formatted_max_size);
+    if (g_klog_state.message_formatted_max_size != message_total_length_length) {
+        printf("Klog message max length should be %d but it is %d\n", message_total_length_length, g_klog_state.message_formatted_max_size);
         return 1;
     }
 
@@ -60,13 +61,13 @@ int no_async_param(
         return 1;
     }
 
-    char* empty_message_buffer = malloc(message_max_length);
-    memset(empty_message_buffer, 0, message_max_length);
+    char* empty_message_buffer = malloc(message_total_length_length);
+    memset(empty_message_buffer, 0, message_total_length_length);
     if (g_klog_state.b_messages_formatted == NULL) {
         printf("Klog formatted message buffer is not initialized\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer, message_max_length)) {
+    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer, message_total_length_length)) {
         printf("Klog formatted messages buffer should be all null characters but it is not\n");
         return 1;
     }
@@ -109,12 +110,13 @@ int no_async_param(
 int single_element(
     void
 ) {
-    const uint32_t  logger_name_length = 8;
-    const uint32_t  message_max_length = 11;
-    const uint32_t  num_elements       = 1;
-    KlogFormatInfo  format_info        = { logger_name_length, message_max_length, 0, false, false };
-    KlogAsyncInfo   async_info         = { num_elements, 3 };
-    KlogConsoleInfo console_info       = { KLOG_LEVEL_INFO, false };
+    const uint32_t  logger_name_length   = 8;
+    const uint32_t  message_max_length   = 11;
+    const uint32_t  message_total_length = message_max_length + 1;
+    const uint32_t  num_elements         = 1;
+    KlogFormatInfo  format_info          = { logger_name_length, message_max_length, 0, false, false };
+    KlogAsyncInfo   async_info           = { num_elements, 3 };
+    KlogConsoleInfo console_info         = { KLOG_LEVEL_INFO, false };
     klog_initialize(5, format_info, &async_info, &console_info, NULL, NULL);
 
     if (g_klog_state.message_element_idx != 0) {
@@ -137,8 +139,8 @@ int single_element(
         return 1;
     }
 
-    if (g_klog_state.message_formatted_max_size != message_max_length) {
-        printf("Klog message max length should be %d but it is %d\n", message_max_length, g_klog_state.message_formatted_max_size);
+    if (g_klog_state.message_formatted_max_size != message_max_length + 1) {
+        printf("Klog message max length should be %d but it is %d\n", message_max_length + 1, g_klog_state.message_formatted_max_size);
         return 1;
     }
 
@@ -161,13 +163,13 @@ int single_element(
         return 1;
     }
 
-    char* empty_message_buffer = malloc(message_max_length);
-    memset(empty_message_buffer, 0, message_max_length);
+    char* empty_message_buffer = malloc(message_total_length);
+    memset(empty_message_buffer, 0, message_total_length);
     if (g_klog_state.b_messages_formatted == NULL) {
         printf("Klog formatted message buffer is not initialized\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer, message_max_length)) {
+    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer, message_total_length)) {
         printf("Klog formatted messages buffer should be all null characters but it is not\n");
         return 1;
     }
@@ -210,13 +212,14 @@ int single_element(
 int multiple_elements(
     void
 ) {
-    const uint32_t  num_loggers        = 4;
-    const uint32_t  logger_name_length = 3;
-    const uint32_t  message_max_length = 7; /* good length to set manually if needed */
-    const uint32_t  num_elements       = 3;
-    KlogFormatInfo  format_info        = { logger_name_length, message_max_length, 0, false, false };
-    KlogAsyncInfo   async_info         = { num_elements, 3 };
-    KlogConsoleInfo console_info       = { KLOG_LEVEL_DEBUG, false };
+    const uint32_t  num_loggers          = 4;
+    const uint32_t  logger_name_length   = 3;
+    const uint32_t  message_max_length   = 7; /* good length to set manually if needed */
+    const uint32_t  message_total_length = message_max_length + 1; /* +1 because each is null terminated */
+    const uint32_t  num_elements         = 3;
+    KlogFormatInfo  format_info          = { logger_name_length, message_max_length, 0, false, false };
+    KlogAsyncInfo   async_info           = { num_elements, 3 };
+    KlogConsoleInfo console_info         = { KLOG_LEVEL_DEBUG, false };
     klog_initialize(num_loggers, format_info, &async_info, &console_info, NULL, NULL);
 
     if (g_klog_state.message_element_idx != 0) {
@@ -239,8 +242,8 @@ int multiple_elements(
         return 1;
     }
 
-    if (g_klog_state.message_formatted_max_size != message_max_length) {
-        printf("Klog message max length should be %d but it is %d\n", message_max_length, g_klog_state.message_formatted_max_size);
+    if (g_klog_state.message_formatted_max_size != message_total_length) {
+        printf("Klog message max length should be %d but it is %d\n", message_total_length, g_klog_state.message_formatted_max_size);
         return 1;
     }
 
@@ -263,21 +266,21 @@ int multiple_elements(
         return 1;
     }
 
-    char* empty_message_buffer_all = malloc(message_max_length * num_elements);
-    memset(empty_message_buffer_all, 0, message_max_length * num_elements);
+    char* empty_message_buffer_all = malloc(message_total_length * num_elements);
+    memset(empty_message_buffer_all, 0, message_total_length * num_elements);
     if (g_klog_state.b_messages_formatted == NULL) {
         printf("Klog formatted message buffer is not initialized\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer_all, message_max_length * num_elements)) {
+    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer_all, message_total_length * num_elements)) {
         printf("Klog formatted messages buffer should be all null characters but it is not\n");
         return 1;
     }
 
-    char* dirty_message_buffer_all = malloc(message_max_length * num_elements);
-    memset(dirty_message_buffer_all, 'K', message_max_length * num_elements);
-    memcpy(g_klog_state.b_messages_formatted, dirty_message_buffer_all, message_max_length * num_elements); /* Dirty all message buffers to validate clear logic */
-    if (memcmp(g_klog_state.b_messages_formatted, dirty_message_buffer_all, message_max_length * num_elements)) {
+    char* dirty_message_buffer_all = malloc(message_total_length * num_elements);
+    memset(dirty_message_buffer_all, 'K', message_total_length * num_elements);
+    memcpy(g_klog_state.b_messages_formatted, dirty_message_buffer_all, message_total_length * num_elements); /* Dirty all message buffers to validate clear logic */
+    if (memcmp(g_klog_state.b_messages_formatted, dirty_message_buffer_all, message_total_length * num_elements)) {
         printf("Klog formatted messages buffer should be all dirty characters but it is not\n");
         return 1;
     }
@@ -285,19 +288,19 @@ int multiple_elements(
     /* First logging statement */
 
     printf("Buffer before first log:\n");
-    for (uint32_t byte_idx = 0; byte_idx < message_max_length * num_elements; ++byte_idx) {
+    for (uint32_t byte_idx = 0; byte_idx < message_total_length * num_elements; ++byte_idx) {
         const char    byte   = g_klog_state.b_messages_formatted[byte_idx];
         const int16_t casted = (int16_t)byte;
         printf("%d = %d\n", byte_idx, casted);
     }
 
-    char* dirty_message_buffer = malloc(message_max_length);
-    memset(dirty_message_buffer, 'K', message_max_length);
-    if (memcmp(g_klog_state.b_messages_formatted + (message_max_length * 0), dirty_message_buffer, message_max_length)) {
+    char* dirty_message_buffer = malloc(message_total_length);
+    memset(dirty_message_buffer, 'K', message_total_length);
+    if (memcmp(g_klog_state.b_messages_formatted + (message_total_length * 0), dirty_message_buffer, message_total_length)) {
         printf(
             "Klog formatted message buffer element 0 should be dirty ('K') before logging anything, but instead it contains \"%.*s\"\n",
-            message_max_length,
-            g_klog_state.b_messages_formatted + (message_max_length * 0)
+            message_total_length,
+            g_klog_state.b_messages_formatted + (message_total_length * 0)
         );
         return 1;
     }
@@ -313,8 +316,8 @@ int multiple_elements(
         return 1;
     }
 
-    char* empty_message_buffer = malloc(message_max_length);
-    memset(empty_message_buffer, 0, message_max_length);
+    char* empty_message_buffer = malloc(message_total_length);
+    memset(empty_message_buffer, 0, message_total_length);
 
     const KlogLoggerHandle* p = klog_logger_create("dum");
     klog_logger_level_set(p, KLOG_LEVEL_INFO);
@@ -343,10 +346,10 @@ int multiple_elements(
         return 1;
     }
 
-    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer, message_max_length)) {
+    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer, message_total_length)) {
         printf(
             "Klog formatted message buffer element 0 should be empty (cleared) after logging at info level, but instead it contains \"%.*s\"\n",
-            message_max_length,
+            message_total_length,
             g_klog_state.b_messages_formatted
         );
         return 1;
@@ -355,7 +358,7 @@ int multiple_elements(
     /* Second logging statement */
 
     printf("Buffer after first log:\n");
-    for (uint32_t byte_idx = 0; byte_idx < message_max_length * num_elements; ++byte_idx) {
+    for (uint32_t byte_idx = 0; byte_idx < message_total_length * num_elements; ++byte_idx) {
         const char    byte   = g_klog_state.b_messages_formatted[byte_idx];
         const int16_t casted = (int16_t)byte;
         printf("%d = %d\n", byte_idx, casted);
@@ -363,15 +366,15 @@ int multiple_elements(
 
     printf(
         "!!!!!!!!Checking buffer starting %p through %p (%d bytes)\n",
-        g_klog_state.b_messages_formatted + (message_max_length * 1),
-        g_klog_state.b_messages_formatted + (message_max_length * 1) + message_max_length,
+        g_klog_state.b_messages_formatted + (message_total_length * 1),
+        g_klog_state.b_messages_formatted + (message_total_length * 1) + message_total_length,
         message_max_length
     );
-    if (memcmp(g_klog_state.b_messages_formatted + (message_max_length * 1), dirty_message_buffer, message_max_length)) {
+    if (memcmp(g_klog_state.b_messages_formatted + (message_total_length * 1), dirty_message_buffer, message_total_length)) {
         printf(
             "Klog formatted message buffer element 1 should be dirty ('K') after logging at info level 1 time, but instead it contains \"%.*s\"\n",
-            message_max_length,
-            g_klog_state.b_messages_formatted + (message_max_length * 1)
+            message_total_length,
+            g_klog_state.b_messages_formatted + (message_total_length * 1)
         );
         return 1;
     }
@@ -413,11 +416,11 @@ int multiple_elements(
         return 1;
     }
 
-    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer, message_max_length)) {
+    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer, message_total_length)) {
         printf(
             "Klog formatted message buffer element 1 should be empty (cleared) after logging at info level 2 times, but instead it contains \"%.*s\"\n",
-            message_max_length,
-            g_klog_state.b_messages_formatted + (message_max_length * 1)
+            message_total_length,
+            g_klog_state.b_messages_formatted + (message_total_length * 1)
         );
         return 1;
     }
@@ -527,10 +530,10 @@ int noop(
 int main(
     void
 ) {
-    /* int result = no_async_param() || single_element() || multiple_elements() || noop(); */
+    int result = no_async_param() || single_element() || multiple_elements() || noop();
     /* int result = no_async_param(); */
     /* int result = single_element(); */
-    int result = multiple_elements();
+    /* int result = multiple_elements(); */
 
     return result;
 }

--- a/src/klog/ut/ut-klog_ring_buffer_usage.c
+++ b/src/klog/ut/ut-klog_ring_buffer_usage.c
@@ -531,9 +531,6 @@ int main(
     void
 ) {
     int result = no_async_param() || single_element() || multiple_elements() || noop();
-    /* int result = no_async_param(); */
-    /* int result = single_element(); */
-    /* int result = multiple_elements(); */
 
     return result;
 }


### PR DESCRIPTION
# v0.0.14 Ring buffer for formatted messages

<!--
Include updated version, and use imperative mood.
Ex:

v1.2.3 rename boop to beep
-->

---

## Description

<!--
What does this change do?

- Describe the previous behavior and why it was bad.
- Describe the updated behavior and why it is good.
-->

- Previously our formatted message buffer was only large enough for 1 message
- This change introduces logic to create and index into a ring buffer for formatted messages
- This is important because we need multiple message slots for asynchronous logging, which is coming down the pipeline soon

### Implementation Details

<!--
What changes were made in order to get the desired, updated behavior?

- Give details that will help reviewers understand what is going on.
-->

- we had to change the size of the formatted message buffer which we are allocating
    - each message is sized according to the user's input, +1 byte for a null terminator
- we had to make changes to how we format the input message, and determine its length with the null terminator accounted for
    - this also resulted in a performance increase because we got rid of one of the `vsnprintf` invocations

---

## Motivation

<!--
Why is this change needed?

- What problem does it solve?
- Why is this the correct fix? Why not alternative approaches?
-->

- This is necessary for asynchronous logging, so each thread can have a different message queued up for consumption, while the producer/main thread can still write to the ring buffer

### Related Issues

<!--
Which issues does this close? Ex:

- closes #1
- closes #42
-->

- closes #36 

---

## Testing

<!--
How was this validated?

- Were new tests added? If so, which ones?
- Which currently in place tests are relevant?
- Include logs, traces, or minimal repro steps if applicable.
-->

- tests are in `ut-klog_ring_buffer_usage.c` (formerly `ut-klog_prefix_buffer_usage.c`)
- `ft-klog_basic.c` was updated t validate that empty lines are logged correctly, and that message lenght is enforced correctly after this change

---

## Checklist

- [x] Adherance to style guide (naming and formatting)
- [x] All tests pass
- [x] New tests added where appropriate
- [x] Documentation updated (everything exposed in headers really)
- [x] Concurrency implications considered
- [x] Self review performed
- [x] Version incremented if appropriate

---
