### PR TITLE
v0.0.15 Logger name formatting allocation fix (don't allocate upon logger creation)

### DIFF
--- a/cmake/KlogVersion.cmake
+++ b/cmake/KlogVersion.cmake
@@ -18,4 +18,5 @@ endfunction()
 # set_klog_versions(0 0 11) # EOF Newlines
 # set_klog_versions(0 0 12) # Pre-allocate message buffer, don't malloc for message formatting
 # set_klog_versions(0 0 13) # Allow users to specify callbacks for custom allocation and free logic
-set_klog_versions(0 0 14) # Pre-allocate multiple formatted input message buffer to prep for multi-threading support
+# set_klog_versions(0 0 14) # Pre-allocate multiple formatted input message buffer to prep for multi-threading support
+set_klog_versions(0 0 15) # Don't allocate when formatting logger names

--- a/include/klog/klog.h
+++ b/include/klog/klog.h
@@ -103,12 +103,16 @@ void klog_deinitialize(
  * @pre klog has been initialized.
  * @pre There exists fewer than KLOG_MAX_NUMBER_LOGGERS, if a logger for the
  *      given name does not exist.
+ * @pre name_length is greater than 0
  * @param logger_name The name of the logger to create
+ * @param name_length The length of the provided logger name (not including null
+ *      terminator if it is present)
  * @returns KlogLoggerHandle The newly created handle if logger_name did
  *      not already exist, or the retrieved handle if logger_name did exist
  */
 const KlogLoggerHandle* klog_logger_create(
-    const char* s_logger_name
+    const char* s_logger_name,
+    uint32_t    name_length
 );
 
 /**

--- a/src/klog/ft/ft-klog_basic.c
+++ b/src/klog/ft/ft-klog_basic.c
@@ -6,6 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "../klog_debug_util.h"
 
@@ -20,7 +21,7 @@ int main(
     klog_initialize(4, format_info, NULL, &console_info, &file_info, NULL);
 
     kdprintf("CREATING HANDLE\n");
-    const KlogLoggerHandle* handle_1 = klog_logger_create("My Logger");
+    const KlogLoggerHandle* handle_1 = klog_logger_create("My Logger", 8);
     kdprintf("LOGGING BEFORE SETTING LEVEL\n");
     klog(handle_1, KLOG_LEVEL_INFO, "This should not appear");
     kdprintf("SETTING LEVEL TO DEBUG\n");
@@ -51,12 +52,12 @@ int main(
     klog(handle_1, KLOG_LEVEL_WARN, "DONE LOGGING 3 EMPTY LINES");
 
 #ifndef KLOG_DEBUG
-    const KlogLoggerHandle* handle_2 = klog_logger_create("B");
+    const KlogLoggerHandle* handle_2 = klog_logger_create("B", 1);
     klog_logger_level_set(handle_2, 6);
     klog(handle_2, KLOG_LEVEL_TRACE, "What's up - trace level - second log statement");
 
     const char*             name_3          = "ABC";
-    const KlogLoggerHandle* handle_3        = klog_logger_create(name_3);
+    const KlogLoggerHandle* handle_3        = klog_logger_create(name_3, strlen(name_3));
     const KlogLoggerHandle* handle_3_custom = handle_3;
     klog_logger_level_set(handle_3_custom, KLOG_LEVEL_INFO);
     klog(handle_3_custom, 6, "Logger ABC should not log trace");
@@ -68,7 +69,7 @@ int main(
     klog(handle_3, KLOG_LEVEL_ERROR, "This should be an error!!");
     klog(handle_3, KLOG_LEVEL_FATAL, "THIS SHOULD BE FATAL!!!!!!!!!");
 
-    const KlogLoggerHandle* handle_4_custom = klog_logger_create("123456");
+    const KlogLoggerHandle* handle_4_custom = klog_logger_create("123456", 6);
     klog(handle_4_custom, 5, "Logging with an off logger shouldn't do anything");
     klog_logger_level_set(handle_4_custom, KLOG_LEVEL_INFO);
     klog(handle_4_custom, KLOG_LEVEL_INFO, "Multiple formats (one - %d)\ntwo\n\n%s%d\n5", 1, "four", 4);

--- a/src/klog/ft/ft-klog_basic.c
+++ b/src/klog/ft/ft-klog_basic.c
@@ -74,6 +74,7 @@ int main(
     klog(handle_4_custom, KLOG_LEVEL_INFO, "Multiple formats (one - %d)\ntwo\n\n%s%d\n5", 1, "four", 4);
 #endif
 
+    klog(handle_1, KLOG_LEVEL_INFO, "ALL DONE");
     kdprintf("DEINITIALIZING KLOG\n");
     klog_deinitialize();
 

--- a/src/klog/ft/ft-klog_console.c
+++ b/src/klog/ft/ft-klog_console.c
@@ -15,13 +15,13 @@ void do_it(
     KlogConsoleInfo stdout_info = { KLOG_LEVEL_TRACE, use_color };
     klog_initialize(2, format_info, NULL, &stdout_info, NULL, NULL);
 
-    const KlogLoggerHandle* handle_1 = klog_logger_create("Logger");
+    const KlogLoggerHandle* handle_1 = klog_logger_create("Logger", 6);
     klog_logger_level_set(handle_1, KLOG_LEVEL_TRACE);
     klog(handle_1, KLOG_LEVEL_INFO,  "0123456789AAAAAAAA");
     klog(handle_1, KLOG_LEVEL_DEBUG, "Debug logging");
     klog(handle_1, KLOG_LEVEL_INFO,  "format %d %f stuff %s", 42, 42.42f, "fourty two");
 
-    const KlogLoggerHandle* handle_2 = klog_logger_create("B");
+    const KlogLoggerHandle* handle_2 = klog_logger_create("B", 1);
     klog_logger_level_set(handle_2, 6);
     klog(handle_2, KLOG_LEVEL_TRACE, "What's up - trace level - second log statement");
 

--- a/src/klog/ft/ft-klog_fail_level.c
+++ b/src/klog/ft/ft-klog_fail_level.c
@@ -11,7 +11,7 @@ int main(
 ) {
     klog_initialize(1, (KlogFormatInfo) { 10, 5, 0, false, false }, NULL, NULL, NULL, NULL);
 
-    const KlogLoggerHandle* p_handle = klog_logger_create("ABCDE");
+    const KlogLoggerHandle* p_handle = klog_logger_create("ABCDE", 5);
 
     const uint32_t desired_level = KLOG_LEVEL_TRACE + 1;
     klog(p_handle, desired_level, "This should cause a program exit");

--- a/src/klog/ft/ft-klog_fail_logger_limit.c
+++ b/src/klog/ft/ft-klog_fail_logger_limit.c
@@ -5,6 +5,7 @@
 #include "klog/klog.h"
 
 #include <stdio.h>
+#include <string.h>
 
 #include "../klog_debug_util.h"
 
@@ -15,7 +16,7 @@ int main(
     KlogFormatInfo format_info = { 6, 100, 20, true, false };
     klog_initialize(2, format_info, NULL, NULL, NULL, NULL);
 
-    const KlogLoggerHandle* handle_1 = klog_logger_create("MyLogger");
+    const KlogLoggerHandle* handle_1 = klog_logger_create("MyLogger", 7);
     klog(handle_1, KLOG_LEVEL_INFO, "This should not appear");
     klog_logger_level_set(handle_1, KLOG_LEVEL_DEBUG);
     klog(handle_1, KLOG_LEVEL_TRACE, "This should also not appear");
@@ -29,7 +30,7 @@ int main(
     );
 
     kdprintf("Creating second logger\n");
-    const KlogLoggerHandle* handle_2 = klog_logger_create("B");
+    const KlogLoggerHandle* handle_2 = klog_logger_create("B", 1);
     kdprintf("Setting level for second logger\n");
     klog_logger_level_set(handle_2, 6);
     kdprintf("Logging with second logger\n");
@@ -39,7 +40,7 @@ int main(
 
     const char* name_3 = "ABC";
     kdprintf("Creating third logger\n");
-    const KlogLoggerHandle* handle_3 = klog_logger_create(name_3);
+    const KlogLoggerHandle* handle_3 = klog_logger_create(name_3, strlen(name_3));
     kdprintf("Logging with third logger\n");
     klog(handle_3, KLOG_LEVEL_TRACE, "We should fail before we ever get here");
 

--- a/src/klog/ft/ft-klog_fail_uninitialized.c
+++ b/src/klog/ft/ft-klog_fail_uninitialized.c
@@ -10,7 +10,7 @@ int main(
     void
 ) {
     /* Fail because klog is uninitialized */
-    const KlogLoggerHandle* handle_1 = klog_logger_create("MyLogger");
+    const KlogLoggerHandle* handle_1 = klog_logger_create("MyLogger", 8);
     klog(handle_1, KLOG_LEVEL_INFO, "This should not appear");
     klog_logger_level_set(handle_1, KLOG_LEVEL_DEBUG);
     klog(handle_1, KLOG_LEVEL_TRACE, "This should also not appear");

--- a/src/klog/ft/ft-klog_file.c
+++ b/src/klog/ft/ft-klog_file.c
@@ -17,7 +17,7 @@ int main(
     KlogFileInfo   file_info   = { KLOG_LEVEL_INFO, "FILE__PREFIX____OR_WHATEVER_THIS_PREFIX_IS_LONG" };
     klog_initialize(4, format_info, NULL, NULL, &file_info, NULL);
 
-    const KlogLoggerHandle* handle_1 = klog_logger_create("MyLogger");
+    const KlogLoggerHandle* handle_1 = klog_logger_create("MyLogger", 8);
     klog_logger_level_set(handle_1, KLOG_LEVEL_DEBUG);
     klog(handle_1, KLOG_LEVEL_TRACE, "This should not appear due to the logger's max verbosity");
     klog(handle_1, KLOG_LEVEL_DEBUG, "This should not appear due to the file's max verbosity");
@@ -26,12 +26,12 @@ int main(
     klog(handle_1, KLOG_LEVEL_ERROR, "Big Error");
     klog(handle_1, KLOG_LEVEL_FATAL, "Huge Error");
 
-    const KlogLoggerHandle* handle_2 = klog_logger_create("Boo With Some Spaces In Here");
+    const KlogLoggerHandle* handle_2 = klog_logger_create("Boo With Some Spaces In Here", 20);
     klog_logger_level_set(handle_2, KLOG_LEVEL_ERROR);
     klog(handle_2, KLOG_LEVEL_ERROR, "Truncate__Logging at the max verbosity level for the second logger");
 
-    const KlogLoggerHandle* handle_3 = klog_logger_create("ABC");
-    const KlogLoggerHandle* handle_4 = klog_logger_create("  ..  \\\\AAAAAAA");
+    const KlogLoggerHandle* handle_3 = klog_logger_create("ABC", 3);
+    const KlogLoggerHandle* handle_4 = klog_logger_create("  ..  \\\\AAAAAAA", 9);
 
     const KlogLoggerHandle* a_handles[NUM_HANDLES] = { handle_1, handle_2, handle_3, handle_4 };
     for (uint32_t i = 0; i < NUM_HANDLES; ++i) {

--- a/src/klog/ft/ft-klog_stress_st_sync.c
+++ b/src/klog/ft/ft-klog_stress_st_sync.c
@@ -28,7 +28,7 @@ void do_test(
         char* const s_logger_name = malloc(4);
         sprintf(s_logger_name, "%.3d", i);
 
-        a_handles[i] = klog_logger_create(s_logger_name);
+        a_handles[i] = klog_logger_create(s_logger_name, 3);
         klog_logger_level_set(a_handles[i], KLOG_LEVEL_TRACE);
 
         free(s_logger_name);

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -237,8 +237,8 @@ void klog_deinitialize(
 }
 
 const KlogLoggerHandle* klog_logger_create(
-    const char* const s_logger_name
-    /* @todo take the logger name length as a parameter because we can't rely on it being null terminated */
+    const char* const s_logger_name,
+    const uint32_t    name_length
 ) {
 #ifdef KLOG_OFF
     (void)logger_name;
@@ -254,12 +254,17 @@ const KlogLoggerHandle* klog_logger_create(
         exit(KLOG_EXIT_CODE);
     }
 
+    if (name_length <= 0) {
+        kdprintf("Trying to create klog logger, the length of the provided name is 0\n");
+        exit(KLOG_EXIT_CODE);
+    }
+
     const uint32_t current_logger_index = g_klog_state.number_loggers_created;
 
     const uint32_t logger_name_start_index = current_logger_index * g_klog_config.format.logger_name_max_length;
     klog_format_logger_name(
         s_logger_name,
-        strlen(s_logger_name), /* @todo take this via parameter */
+        name_length,
         &g_klog_state.b_logger_names[logger_name_start_index], /* This is initialized to spaces */
         g_klog_config.format.logger_name_max_length
     );

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -238,6 +238,7 @@ void klog_deinitialize(
 
 const KlogLoggerHandle* klog_logger_create(
     const char* const s_logger_name
+    /* @todo take the logger name length as a parameter because we can't rely on it being null terminated */
 ) {
 #ifdef KLOG_OFF
     (void)logger_name;
@@ -255,14 +256,13 @@ const KlogLoggerHandle* klog_logger_create(
 
     const uint32_t current_logger_index = g_klog_state.number_loggers_created;
 
-    const char* const s_sanitized_name = klog_format_logger_name(s_logger_name, g_klog_config.alloc.alloc_cb);
-
     const uint32_t logger_name_start_index = current_logger_index * g_klog_config.format.logger_name_max_length;
-    const uint32_t number_chars_to_copy    = strlen(s_sanitized_name) >= g_klog_config.format.logger_name_max_length
-        ? g_klog_config.format.logger_name_max_length /* copy as much as we can fit */
-        : strlen(s_sanitized_name); /* copy it all - NOT including the null terminator (which strlen doesn't count anyways) */
-    memcpy(&g_klog_state.b_logger_names[logger_name_start_index], s_sanitized_name, number_chars_to_copy);
-    g_klog_config.alloc.free_cb((char*)s_sanitized_name);
+    klog_format_logger_name(
+        s_logger_name,
+        strlen(s_logger_name), /* @todo take this via parameter */
+        &g_klog_state.b_logger_names[logger_name_start_index], /* This is initialized to spaces */
+        g_klog_config.format.logger_name_max_length
+    );
 
     g_klog_state.a_logger_levels[current_logger_index] = KLOG_LEVEL_OFF;
 

--- a/src/klog/klog_format.c
+++ b/src/klog/klog_format.c
@@ -60,6 +60,23 @@ void klog_format_logger_name(
     char*             b_output,
     const uint32_t    max_length
 ) {
+    if (s_name == NULL) {
+        kdprintf("Trying to format logger name, but the provided name is NULL\n");
+        exit(KLOG_EXIT_CODE);
+    }
+
+    if (name_unformatted_length <= 0) {
+        kdprintf("Trying to format logger name, but the length of the provided name is 0\n");
+        exit(KLOG_EXIT_CODE);
+    }
+
+    if (b_output == NULL) {
+        kdprintf("Trying to format logger name, but the provided output buffer is NULL\n");
+        exit(KLOG_EXIT_CODE);
+    }
+
+    memset(b_output, ' ', max_length);
+
     const uint32_t length_actual = max_length < name_unformatted_length ? max_length : name_unformatted_length;
 
     for (uint32_t i_char = 0; i_char < length_actual; ++i_char) {

--- a/src/klog/klog_format.c
+++ b/src/klog/klog_format.c
@@ -40,20 +40,6 @@ uint32_t klog_format_prefix_length_get(
     return total;
 }
 
-/**
- * @todo Instead of taking the allocation callback and allocating space for the sanitized version,
- *      we need to take the output buffer (and its size) via parameter, and just iterate over the
- *      input s_name parameter and sanitize while we manually copy into the ouptut buffer.
- *
- *      This will require a small rethink about how we want to do the file name formatting function
- *      as it invokes this one. We will probably just need to allocate in that function, then pass
- *      the newly allocated buffer to this function.
- *
- *      We should probably also rename this function to klog_format_sanitize_whitespace or something
- *      of the sort to denote that it isn't just for logger names.
- *
- *  @brief The output buffer will NOT be null terminated
- */
 void klog_format_logger_name(
     const char* const s_name,
     const uint32_t    name_unformatted_length,
@@ -95,19 +81,12 @@ void klog_format_logger_name(
     }
 }
 
-/**
- * @brief The resulting buffer is null terminated
- */
 const char* klog_format_file_name_prefix(
     const char* const s_name,
     void* (* const    alloc_cb)(
         size_t size
     )
 ) {
-    /**
-     * Perhaps we should be doing this in place but creating the file only happens once so, oh well
-     */
-
     /* @todo kjk 2026/02/12 Should we be doing anything to sanitize filepaths for windows vs linux? Convert "/" to "\\" and vice versa?? */
 
     const uint32_t length   = strlen(s_name);

--- a/src/klog/klog_format.c
+++ b/src/klog/klog_format.c
@@ -51,23 +51,19 @@ uint32_t klog_format_prefix_length_get(
  *
  *      We should probably also rename this function to klog_format_sanitize_whitespace or something
  *      of the sort to denote that it isn't just for logger names.
+ *
+ *  @brief The output buffer will NOT be null terminated
  */
-const char* klog_format_logger_name(
+void klog_format_logger_name(
     const char* const s_name,
-    void* (* const    alloc_cb)(
-        size_t size
-    )
+    const uint32_t    name_unformatted_length,
+    char*             b_output,
+    const uint32_t    max_length
 ) {
-    /**
-     * Perhaps we should be doing this in place but creating loggers is not where we will
-     * be saving on performance, so mallocing a copy is okay
-     */
+    const uint32_t length_actual = max_length < name_unformatted_length ? max_length : name_unformatted_length;
 
-    const uint32_t length_name      = strlen(s_name);
-    char*          s_sanitized_name = alloc_cb(length_name + 1); /* +1 for null termination */
-
-    for (uint32_t i_input_char = 0; i_input_char < length_name; ++i_input_char) {
-        const char curr_char     = s_name[i_input_char];
+    for (uint32_t i_char = 0; i_char < length_actual; ++i_char) {
+        char       curr_char     = s_name[i_char];
         const bool is_whitespace = (curr_char == '\n')
             || (curr_char == '\t')
             || (curr_char == ' ')
@@ -75,18 +71,16 @@ const char* klog_format_logger_name(
             || (curr_char == '\b')
             || (curr_char == '\0');
         if (is_whitespace) {
-            s_sanitized_name[i_input_char] = '_';
-            continue;
+            curr_char = '_';
         }
 
-        s_sanitized_name[i_input_char] = curr_char;
+        b_output[i_char] = curr_char;
     }
-
-    s_sanitized_name[length_name] = '\0';
-
-    return s_sanitized_name;
 }
 
+/**
+ * @brief The resulting buffer is null terminated
+ */
 const char* klog_format_file_name_prefix(
     const char* const s_name,
     void* (* const    alloc_cb)(
@@ -99,7 +93,13 @@ const char* klog_format_file_name_prefix(
 
     /* @todo kjk 2026/02/12 Should we be doing anything to sanitize filepaths for windows vs linux? Convert "/" to "\\" and vice versa?? */
 
-    return klog_format_logger_name(s_name, alloc_cb);
+    const uint32_t length   = strlen(s_name);
+    char*          b_output = alloc_cb(length + 1);
+    memset(b_output, 0, length + 1);
+
+    klog_format_logger_name(s_name, length, b_output, length);
+
+    return b_output;
 }
 
 KlogString klog_format_message_prefix(

--- a/src/klog/klog_format.h
+++ b/src/klog/klog_format.h
@@ -19,6 +19,25 @@ uint32_t klog_format_prefix_length_get(
     const uint32_t source_location_filename_max_length
 );
 
+/**
+ * @brief Format the logger name (convert all whitespaces to underscores)
+ * @detail Convert all white spaces to underscores for the given logger name.
+ *      The output is stored in the b_output parameter. If the provided logger
+ *      name is shorter than max_length, then the output buffer will be appended
+ *      with spaces after the logger name to make a string of max_length characters.
+ *      All "whitespace" characters are converted to '_' characters. Whitespace
+ *      characters are '\t', ' ', '\r', '\b', and '\0'.
+ * @pre s_name must be non-NULL
+ * @pre name_unformatted_length must be greater than 0
+ * @pre b_output must be non-NULL and at least max_length bytes large
+ * @pre max_length must be greater than 0
+ * @param s_name                  The unformatted logger name
+ * @param name_unformatted_length The length in characters of the unformatted logger
+ *      name. This is so we don't need to rely upon null terminated logger name strings
+ * @param b_output                The output buffer
+ * @param max_length              The maximum length of the formatted logger name
+ * @returns The formatted logger name is stored in b_output
+ */
 void klog_format_logger_name(
     const char*    s_name,
     const uint32_t name_unformatted_length,

--- a/src/klog/klog_format.h
+++ b/src/klog/klog_format.h
@@ -21,7 +21,7 @@ uint32_t klog_format_prefix_length_get(
 
 /**
  * @brief Format the logger name (convert all whitespaces to underscores)
- * @detail Convert all white spaces to underscores for the given logger name.
+ * @details Convert all white spaces to underscores for the given logger name.
  *      The output is stored in the b_output parameter. If the provided logger
  *      name is shorter than max_length, then the output buffer will be appended
  *      with spaces after the logger name to make a string of max_length characters.
@@ -36,7 +36,8 @@ uint32_t klog_format_prefix_length_get(
  *      name. This is so we don't need to rely upon null terminated logger name strings
  * @param b_output                The output buffer
  * @param max_length              The maximum length of the formatted logger name
- * @returns The formatted logger name is stored in b_output
+ * @returns The formatted logger name is stored in b_output. The output will NOT be
+ *      null terminated
  */
 void klog_format_logger_name(
     const char*    s_name,
@@ -45,6 +46,15 @@ void klog_format_logger_name(
     const uint32_t max_length
 );
 
+/**
+ * @brief Format the file name prefix
+ * @details This uses klog_format_logger_name to perform the formatting
+ * @pre s_name is null terminated
+ * @param s_name   The unformatted file name
+ * @param alloc_cb The allocation callback. This is used for allocating the output
+ *      buffer which stores the formatted file prefix
+ * @returns A null terminated string representing the formatted file name
+ */
 const char* klog_format_file_name_prefix(
     const char*    s_name,
     void* (* const alloc_cb)(

--- a/src/klog/klog_format.h
+++ b/src/klog/klog_format.h
@@ -19,11 +19,11 @@ uint32_t klog_format_prefix_length_get(
     const uint32_t source_location_filename_max_length
 );
 
-const char* klog_format_logger_name(
+void klog_format_logger_name(
     const char*    s_name,
-    void* (* const alloc_cb)(
-        size_t size
-    )
+    const uint32_t name_unformatted_length,
+    char*          b_output,
+    const uint32_t max_length
 );
 
 const char* klog_format_file_name_prefix(

--- a/src/klog/ut/ut-klog_alloc_callback_counts.c
+++ b/src/klog/ut/ut-klog_alloc_callback_counts.c
@@ -69,9 +69,9 @@ int check(
 
     /* create loggers - no allocs or frees */
     printf("Creating logger 0\n");
-    const KlogLoggerHandle* p_handle_0 = klog_logger_create("ABC");
+    const KlogLoggerHandle* p_handle_0 = klog_logger_create("ABC", 3);
     printf("Creating logger 1\n");
-    const KlogLoggerHandle* p_handle_1 = klog_logger_create("DEF");
+    const KlogLoggerHandle* p_handle_1 = klog_logger_create("DEF", 3);
 
     /* logging should introduce no allocs or frees */
     printf("Logging with logger 0\n");

--- a/src/klog/ut/ut-klog_alloc_callback_counts.c
+++ b/src/klog/ut/ut-klog_alloc_callback_counts.c
@@ -67,7 +67,7 @@ int check(
         return 1;
     }
 
-    /* create loggers because this does some allocation for now */
+    /* create loggers - no allocs or frees */
     printf("Creating logger 0\n");
     const KlogLoggerHandle* p_handle_0 = klog_logger_create("ABC");
     printf("Creating logger 1\n");
@@ -80,12 +80,12 @@ int check(
     klog(p_handle_1, KLOG_LEVEL_INFO, "Boop \"%s\"\n", "world");
 
     /* check post logger creation values */
-    const uint32_t alloc_counter_created_expected = alloc_counter_init_expected + 2;
+    const uint32_t alloc_counter_created_expected = alloc_counter_init_expected;
     if (g_alloc_counter != alloc_counter_created_expected) {
         printf("Alloc counter is %d after logger creations when it should be %d\n", g_alloc_counter, alloc_counter_created_expected);
         return 1;
     }
-    const uint32_t free_counter_created_expected = free_counter_init_expected + 2;
+    const uint32_t free_counter_created_expected = free_counter_init_expected;
     if (g_free_counter != free_counter_created_expected) {
         printf("Free counter is %d after logger creations when it should be %d\n", g_free_counter, free_counter_created_expected);
         return 1;

--- a/src/klog/ut/ut-klog_format_logger_name.c
+++ b/src/klog/ut/ut-klog_format_logger_name.c
@@ -13,26 +13,32 @@
 int remove_whitespace(
     void
 ) {
-    const char* s_input = "a b\tc\nd\be\rf  g\n\t\t h";
+    printf("Creating inputs\n");
+    const char*    s_input = "a b\tc\nd\be\rf  g\n\t\t h";
+    const uint32_t length  = strlen(s_input);
 
+    /* Length / size calculations                   */
+    /* 00 +                  0123456789             */
+    /* 10 +                            0123456789   */
     const char* s_expected = "a_b_c_d_e_f__g____h";
 
-    const char* s_actual = klog_format_logger_name(s_input, &malloc);
+    printf("Mallocing output buffer for %d bytes, and memsetting to spaces\n", length);
+    char* s_actual = malloc(length);
+    memset(s_actual, ' ', length);
 
+    printf("Formatting logger name\n");
+    klog_format_logger_name(s_input, length, s_actual, length);
+
+    printf("Performing strcmp\n");
     int result = strcmp(s_input, s_expected);
+    printf("Strcmp result: %d\n", result);
 
     if (result) {
-        const uint32_t length_actual   = strlen(s_actual);
-        const uint32_t length_expected = strlen(s_expected);
+        printf("Result is %d - which is bad?\n", result);
 
-        if (length_actual != length_expected) {
-            printf("Actual and expected strings differ in length:\n");
-            printf("    actual  : %d\n", length_actual);
-            printf("    expected: %d\n", length_expected);
-        }
-        const uint32_t length_min     = length_actual < length_expected ? length_actual : length_expected;
-        uint32_t       mismatch_count = 0;
-        for (uint32_t i = 0; i < length_min; ++i) {
+        uint32_t mismatch_count = 0;
+        for (uint32_t i = 0; i < length; ++i) {
+            printf("Checking chars at index: %d\n", i);
             if (s_actual[i] == s_expected[i]) {
                 continue;
             }
@@ -47,9 +53,51 @@ int remove_whitespace(
             result = 0;
         }
 
-        printf("Strcmp result: %d\n",                  result);
-        printf("Actual   formatted logger name: %s\n", s_actual);
-        printf("Expected formatted logger_name: %s\n", s_expected);
+        printf("Strcmp result: %d\n",                    result);
+        printf("Actual   formatted logger name: %*.s\n", length, s_actual);
+        printf("Expected formatted logger_name: %s\n",   s_expected);
+    }
+    printf("All good!\n");
+
+    free((char*)s_actual);
+
+    return result;
+}
+
+int extra_length(
+    void
+) {
+    const char*    s_input = "a b";
+    const uint32_t length  = 6;
+
+    const char* s_expected = "a_b   ";
+
+    char* s_actual = malloc(length);
+    memset(s_actual, ' ', length);
+    klog_format_logger_name(s_input, 3, s_actual, length);
+
+    int result = strcmp(s_input, s_expected);
+
+    if (result) {
+        uint32_t mismatch_count = 0;
+        for (uint32_t i = 0; i < length; ++i) {
+            if (s_actual[i] == s_expected[i]) {
+                continue;
+            }
+
+            mismatch_count = mismatch_count + 1;
+            printf("%d: actual '%c' != expected '%c'\n", i, s_actual[i], s_expected[i]);
+        }
+        printf("Total number of mismatching characters: %d\n", mismatch_count);
+
+        /* Override the strcmp result. Why does it return -63 when the strings are equal? */
+        if (mismatch_count == 0) {
+            result = 0;
+        }
+
+        printf("Strcmp result: %d\n",                    result);
+        printf("Actual   formatted logger name: %*.s\n", length, s_actual); /* Not null terminated so we need to specify length manually */
+        printf("Expected formatted logger_name: %s\n",   s_expected);
     }
 
     free((char*)s_actual);
@@ -66,6 +114,5 @@ int noop(
 int main(
     void
 ) {
-    return remove_whitespace() || noop()
-    ;
+    return remove_whitespace() || extra_length() || noop();
 }

--- a/src/klog/ut/ut-klog_logger_create.c
+++ b/src/klog/ut/ut-klog_logger_create.c
@@ -29,7 +29,7 @@ int create_single_logger(
         return 1;
     }
 
-    const KlogLoggerHandle* p_handle_0 = klog_logger_create("ABC");
+    const KlogLoggerHandle* p_handle_0 = klog_logger_create("ABC", 3);
     if (g_klog_state.number_loggers_created != 1) {
         printf("Klog reports %d loggers created instead of 1\n", g_klog_state.number_loggers_max);
         return 1;
@@ -65,7 +65,7 @@ int create_multiple_loggers(
         char* s_name = malloc(max_name_length + 1);
         sprintf(s_name, "%.3d", i);
 
-        const KlogLoggerHandle* p_handle = klog_logger_create(s_name);
+        const KlogLoggerHandle* p_handle = klog_logger_create(s_name, max_name_length);
 
         if (g_klog_state.number_loggers_created != (i + 1)) {
             printf("Klog reports %d loggers created instead of %d\n", g_klog_state.number_loggers_max, i + 1);

--- a/src/klog/ut/ut-klog_logger_level_set.c
+++ b/src/klog/ut/ut-klog_logger_level_set.c
@@ -51,7 +51,9 @@ int log_levels_tempfile(
     const uint32_t     max_number_loggers = 100;
     const uint32_t     max_name_length    = 3;
     const KlogFileInfo file_info          = { KLOG_LEVEL_TRACE, "/tmp/ut-klog_logger_level_set" }; /* @todo kjk 2026/02/11 portable tempfile path for windows and mac */
+    printf("Initializing klog\n");
     klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, NULL, NULL, &file_info, NULL);
+    printf("Initializing klog - done\n");
 
     const char*             l_names[KLOG_LEVEL_COUNT]   = { "001", "002", "003", "004", "005", "006", "007" };
     const KlogLoggerHandle* a_handles[KLOG_LEVEL_COUNT] = { NULL, NULL, NULL, NULL, NULL, NULL, NULL };
@@ -61,19 +63,25 @@ int log_levels_tempfile(
 
     /* i acts as the index to the handle, and also as the base accepted level for the handle */
     for (uint32_t i = 0; i < KLOG_LEVEL_COUNT; ++i) {
+        printf("Using handle iteration %d\n", i);
+        printf("creating logger\n");
         a_handles[i] = klog_logger_create(l_names[i]);
+        printf("setting level\n");
         klog_logger_level_set(a_handles[i], i);
 
         /* Ensure that we cannot log something to the tempfile with a level that does not match or equal the base level */
         for (uint32_t i_log_level = 0; i_log_level < KLOG_LEVEL_COUNT; ++i_log_level) {
+            printf("attempting to log at level %d\n", i_log_level);
             if (i_log_level == 0) {
                 continue; /* Logging with the off level is an error */
             }
 
             /* Try to log at the current level */
+            printf("actually logging\n");
             klog(a_handles[i], i_log_level, "beep");
 
             /* Get the filesize */
+            printf("getting file size\n");
             const uint32_t file_size_current = ftell(g_klog_state.p_file);
 
             /* If we should not have logged at this level, ensure the size did not change */
@@ -106,6 +114,6 @@ int noop(
 int main(
     void
 ) {
-    return set_levels() || log_levels_tempfile() || noop()
-    ;
+    return log_levels_tempfile();
+    /* return set_levels() || log_levels_tempfile() || noop(); */
 }

--- a/src/klog/ut/ut-klog_logger_level_set.c
+++ b/src/klog/ut/ut-klog_logger_level_set.c
@@ -114,6 +114,5 @@ int noop(
 int main(
     void
 ) {
-    return log_levels_tempfile();
-    /* return set_levels() || log_levels_tempfile() || noop(); */
+    return set_levels() || log_levels_tempfile() || noop();
 }

--- a/src/klog/ut/ut-klog_logger_level_set.c
+++ b/src/klog/ut/ut-klog_logger_level_set.c
@@ -28,7 +28,7 @@ int set_levels(
         char* s_name = malloc(max_name_length + 1);
         sprintf(s_name, "%.3d", i);
 
-        const KlogLoggerHandle* p_handle = klog_logger_create(s_name);
+        const KlogLoggerHandle* p_handle = klog_logger_create(s_name, max_name_length);
         klog_logger_level_set(p_handle, desired_level);
 
         const uint32_t actual_level = g_klog_state.a_logger_levels[p_handle->value];
@@ -65,7 +65,7 @@ int log_levels_tempfile(
     for (uint32_t i = 0; i < KLOG_LEVEL_COUNT; ++i) {
         printf("Using handle iteration %d\n", i);
         printf("creating logger\n");
-        a_handles[i] = klog_logger_create(l_names[i]);
+        a_handles[i] = klog_logger_create(l_names[i], 3);
         printf("setting level\n");
         klog_logger_level_set(a_handles[i], i);
 

--- a/src/klog/ut/ut-klog_ring_buffer_usage.c
+++ b/src/klog/ut/ut-klog_ring_buffer_usage.c
@@ -72,7 +72,7 @@ int no_async_param(
         return 1;
     }
 
-    const KlogLoggerHandle* p = klog_logger_create("dummy!");
+    const KlogLoggerHandle* p = klog_logger_create("dummy!", 6);
     klog_logger_level_set(p, KLOG_LEVEL_INFO);
     klog_info(p, "test");
 
@@ -174,7 +174,7 @@ int single_element(
         return 1;
     }
 
-    const KlogLoggerHandle* p = klog_logger_create("dummy123");
+    const KlogLoggerHandle* p = klog_logger_create("dummy123", 8);
     klog_logger_level_set(p, KLOG_LEVEL_INFO);
     klog_info(p, "test");
 
@@ -319,7 +319,7 @@ int multiple_elements(
     char* empty_message_buffer = malloc(message_total_length);
     memset(empty_message_buffer, 0, message_total_length);
 
-    const KlogLoggerHandle* p = klog_logger_create("dum");
+    const KlogLoggerHandle* p = klog_logger_create("dum", 3);
     klog_logger_level_set(p, KLOG_LEVEL_INFO);
     klog_info(p, "1234567");
 
@@ -388,7 +388,7 @@ int multiple_elements(
         return 1;
     }
 
-    const KlogLoggerHandle* p2 = klog_logger_create("two");
+    const KlogLoggerHandle* p2 = klog_logger_create("two", 3);
     klog_logger_level_set(p2, KLOG_LEVEL_TRACE);
     klog_trace(p2, "this won't get logged due to the console's min level at debug, and no file logger");
     klog_debug(p2, "test number 2");
@@ -436,7 +436,7 @@ int multiple_elements(
         return 1;
     }
 
-    const KlogLoggerHandle* p3 = klog_logger_create("3");
+    const KlogLoggerHandle* p3 = klog_logger_create("3", 1);
     klog_logger_level_set(p3, KLOG_LEVEL_WARN);
     klog_info(p3, "this won't get logged due to the logger's level");
     klog_error(p3, "test 3");


### PR DESCRIPTION
# v0.0.15 Logger name formatting allocation fix (don't allocate upon logger creation)

<!--
Include updated version, and use imperative mood.
Ex:

v1.2.3 rename boop to beep
-->

---

## Description

<!--
What does this change do?

- Describe the previous behavior and why it was bad.
- Describe the updated behavior and why it is good.
-->

### Implementation Details

<!--
What changes were made in order to get the desired, updated behavior?

- Give details that will help reviewers understand what is going on.
-->

---

## Motivation

<!--
Why is this change needed?

- What problem does it solve?
- Why is this the correct fix? Why not alternative approaches?
-->

### Related Issues

<!--
Which issues does this close? Ex:

- closes #1
- closes #42
-->

- closes #34 

---

## Testing

<!--
How was this validated?

- Were new tests added? If so, which ones?
- Which currently in place tests are relevant?
- Include logs, traces, or minimal repro steps if applicable.
-->

---

## Checklist

- [x] Adherance to style guide (naming and formatting)
- [x] All tests pass
- [x] New tests added where appropriate
- [x] Documentation updated (everything exposed in headers really)
- [x] Concurrency implications considered
- [x] Self review performed
- [x] Version incremented if appropriate

---
