### PR TITLE
v0.0.17 - Async logging threads

### DIFF
--- a/cmake/CreateTest.cmake
+++ b/cmake/CreateTest.cmake
@@ -102,3 +102,11 @@ endfunction()
 function(create_functional_test main_file)
     create_test(${main_file} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ft ${ARGN})
 endfunction()
+
+# --------------------------------------------------------------------------- #
+# Profiling Tests                                                             #
+# --------------------------------------------------------------------------- #
+
+function(create_profiling_test main_file)
+    create_test(${main_file} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/pt ${ARGN})
+endfunction()

--- a/cmake/KlogVersion.cmake
+++ b/cmake/KlogVersion.cmake
@@ -20,4 +20,5 @@ endfunction()
 # set_klog_versions(0 0 13) # Allow users to specify callbacks for custom allocation and free logic
 # set_klog_versions(0 0 14) # Pre-allocate multiple formatted input message buffer to prep for multi-threading support
 # set_klog_versions(0 0 15) # Don't allocate when formatting logger names
-set_klog_versions(0 0 16) # Examples!
+# set_klog_versions(0 0 16) # Examples!
+set_klog_versions(0 0 17) # Async logging with dedicated threads

--- a/src/klog/CMakeLists.txt
+++ b/src/klog/CMakeLists.txt
@@ -8,6 +8,8 @@ add_library(
     klog.c
     klog_state.h
     klog_state.c
+    klog_async.h
+    klog_async.c
     klog_constants.h
     klog_constants.c
     klog_handle.h

--- a/src/klog/CMakeLists.txt
+++ b/src/klog/CMakeLists.txt
@@ -41,6 +41,7 @@ if (KLOG_BUILD_TESTS)
     create_unit_test_plain(ut/ut-klog_logger_level_set.c klog)
     create_unit_test_plain(ut/ut-klog_ring_buffer_usage.c klog)
 
+    create_functional_test(ft/ft-klog_async_1_thread.c klog)
     create_functional_test(ft/ft-klog_basic.c klog)
     create_functional_test(ft/ft-klog_console.c klog)
     create_functional_test(ft/ft-klog_file.c klog)

--- a/src/klog/CMakeLists.txt
+++ b/src/klog/CMakeLists.txt
@@ -44,6 +44,7 @@ if (KLOG_BUILD_TESTS)
 
     create_functional_test(ft/ft-klog_async_1_thread.c klog)
     create_functional_test(ft/ft-klog_async_5_threads.c klog)
+    create_functional_test(ft/ft-klog_async_both.c klog)
     create_functional_test(ft/ft-klog_basic.c klog)
     create_functional_test(ft/ft-klog_console.c klog)
     create_functional_test(ft/ft-klog_file.c klog)

--- a/src/klog/CMakeLists.txt
+++ b/src/klog/CMakeLists.txt
@@ -52,5 +52,5 @@ if (KLOG_BUILD_TESTS)
     create_functional_test(ft/ft-klog_fail_logger_limit.c klog EXPECT_FAILURE IGNORE_MEMORY)
     create_functional_test(ft/ft-klog_fail_level.c klog EXPECT_FAILURE IGNORE_MEMORY)
 
-    # create_functional_test(ft/ft-klog_stress_st_sync.c klog)
+    create_profiling_test(pt/pt-klog_sync_vs_async.c klog)
 endif ()

--- a/src/klog/CMakeLists.txt
+++ b/src/klog/CMakeLists.txt
@@ -29,6 +29,7 @@ target_compile_definitions(klog PUBLIC ${KLOG_COMPILE_DEFINITIONS})
 
 if (KLOG_BUILD_TESTS)
     create_unit_test_plain(ut/ut-klog_alloc_callback_counts.c klog)
+    create_unit_test_plain(ut/ut-klog_async_message_ordering.c klog)
     create_unit_test_plain(ut/ut-klog_deinitialize.c klog)
     create_unit_test_plain(ut/ut-klog_format_input_message.c klog)
     create_unit_test_plain(ut/ut-klog_format_logger_name.c klog)

--- a/src/klog/CMakeLists.txt
+++ b/src/klog/CMakeLists.txt
@@ -42,6 +42,7 @@ if (KLOG_BUILD_TESTS)
     create_unit_test_plain(ut/ut-klog_ring_buffer_usage.c klog)
 
     create_functional_test(ft/ft-klog_async_1_thread.c klog)
+    create_functional_test(ft/ft-klog_async_5_threads.c klog)
     create_functional_test(ft/ft-klog_basic.c klog)
     create_functional_test(ft/ft-klog_console.c klog)
     create_functional_test(ft/ft-klog_file.c klog)

--- a/src/klog/ft/ft-klog_async_1_thread.c
+++ b/src/klog/ft/ft-klog_async_1_thread.c
@@ -12,7 +12,7 @@
 int main(
     void
 ) {
-    KlogFormatInfo  format_info  = { 6, 50, 10, true, true };
+    KlogFormatInfo  format_info  = { 1, 50, 0, false, false };
     KlogAsyncInfo   async_info   = { 7, 1 };
     KlogConsoleInfo console_info = { KLOG_LEVEL_TRACE, true };
     klog_initialize(4, format_info, &async_info, &console_info, NULL, NULL);
@@ -21,7 +21,7 @@ int main(
     klog_logger_level_set(handle, KLOG_LEVEL_TRACE);
 
     for (uint32_t i = 0; i < NUM_LOG_STATEMENTS; ++i) {
-        klog(handle, KLOG_LEVEL_TRACE, "Log statement %d", i);
+        klog(handle, KLOG_LEVEL_WARN, "Log statement %d", i);
     }
 
     klog_deinitialize();

--- a/src/klog/ft/ft-klog_async_1_thread.c
+++ b/src/klog/ft/ft-klog_async_1_thread.c
@@ -1,0 +1,29 @@
+#include "klog/klog.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../klog_debug_util.h"
+
+#define NUM_LOG_STATEMENTS 100
+
+/* This is testing klog with max loggers set to 4, and name length set to 6 */
+int main(
+    void
+) {
+    KlogFormatInfo  format_info  = { 6, 50, 10, true, true };
+    KlogAsyncInfo   async_info   = { 7, 1 };
+    KlogConsoleInfo console_info = { KLOG_LEVEL_TRACE, true };
+    klog_initialize(4, format_info, &async_info, &console_info, NULL, NULL);
+
+    const KlogLoggerHandle* handle = klog_logger_create("async1", 6);
+    klog_logger_level_set(handle, KLOG_LEVEL_TRACE);
+
+    for (uint32_t i = 0; i < NUM_LOG_STATEMENTS; ++i) {
+        klog(handle, KLOG_LEVEL_TRACE, "Log statement %d", i);
+    }
+
+    klog_deinitialize();
+    return 0;
+}

--- a/src/klog/ft/ft-klog_async_5_threads.c
+++ b/src/klog/ft/ft-klog_async_5_threads.c
@@ -6,14 +6,14 @@
 
 #include "../klog_debug_util.h"
 
-#define NUM_LOG_STATEMENTS 20
+#define NUM_LOG_STATEMENTS 2000
 
 /* This is testing klog with max loggers set to 4, and name length set to 6 */
 int main(
     void
 ) {
     KlogFormatInfo  format_info  = { 1, 50, 0, false, false };
-    KlogAsyncInfo   async_info   = { 3, 1 };
+    KlogAsyncInfo   async_info   = { 100, 5 };
     KlogConsoleInfo console_info = { KLOG_LEVEL_TRACE, true };
     klog_initialize(4, format_info, &async_info, &console_info, NULL, NULL);
 

--- a/src/klog/ft/ft-klog_async_both.c
+++ b/src/klog/ft/ft-klog_async_both.c
@@ -6,17 +6,18 @@
 
 #include "../klog_debug_util.h"
 
-#define NUM_LOG_STATEMENTS 20
+#define NUM_LOG_STATEMENTS 50
 
 int main(
     void
 ) {
-    KlogFormatInfo  format_info  = { 1, 50, 0, false, false };
+    KlogFormatInfo  format_info  = { 7, 50, 0, false, false };
     KlogAsyncInfo   async_info   = { 3, 1 };
     KlogConsoleInfo console_info = { KLOG_LEVEL_TRACE, true };
-    klog_initialize(4, format_info, &async_info, &console_info, NULL, NULL);
+    KlogFileInfo    file_info    = { KLOG_LEVEL_TRACE, "klog_async_both" };
+    klog_initialize(4, format_info, &async_info, &console_info, &file_info, NULL);
 
-    const KlogLoggerHandle* handle = klog_logger_create("async1", 6);
+    const KlogLoggerHandle* handle = klog_logger_create("general", 7);
     klog_logger_level_set(handle, KLOG_LEVEL_TRACE);
 
     for (uint32_t i = 0; i < NUM_LOG_STATEMENTS; ++i) {

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -292,8 +292,8 @@ void klog_initialize(
         * g_klog_state.message_element_count
     );
 
-    g_klog_state.filename_string = klog_format_filename(p_klog_file_info, g_klog_config.alloc.alloc_cb, g_klog_config.alloc.free_cb);
-    g_klog_state.p_file          = klog_initialize_file(g_klog_state.filename_string);
+    g_klog_state.s_filename = klog_format_filename(p_klog_file_info, g_klog_config.alloc.alloc_cb, g_klog_config.alloc.free_cb);
+    g_klog_state.p_file     = klog_initialize_file(g_klog_state.s_filename);
 
     g_klog_state.p_mutex_deinitialize = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
     g_klog_state.p_mutex_shared       = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
@@ -409,9 +409,9 @@ void klog_deinitialize(
     g_klog_config.alloc.free_cb(g_klog_state.b_message_levels);
     g_klog_state.b_message_levels = NULL;
 
-    if (g_klog_state.filename_string) {
-        g_klog_config.alloc.free_cb(g_klog_state.filename_string);
-        g_klog_state.filename_string = NULL;
+    if (g_klog_state.s_filename) {
+        g_klog_config.alloc.free_cb(g_klog_state.s_filename);
+        g_klog_state.s_filename = NULL;
     }
     if (g_klog_state.p_file) {
         fclose(g_klog_state.p_file);

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -21,6 +21,19 @@ void* klog_thread_body(
     void* p
 ) {
     (void)p;
+
+    while (true) {
+        /* Check if we should break from the loop */
+        klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
+        if (!g_klog_state.is_initialized) {
+            klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
+            break;
+        }
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
+
+        /* Acquire the formatted message mutex and invoke the "consnuming function" */
+    }
+
     return NULL;
 }
 
@@ -180,12 +193,7 @@ void klog_initialize(
     kdprintf("p_file: %p\n",             (void*)g_klog_state.p_file);
     kdprintf("File max verbosity: %d\n", g_klog_config.file.max_level);
 
-    if (g_klog_config.async.number_backing_threads > 0) {
-        g_klog_state.b_threads = g_klog_config.alloc.alloc_cb(sizeof(kpl_thread_t) * g_klog_config.async.number_backing_threads);
-        for (uint32_t idx_thread = 0; idx_thread < g_klog_config.async.number_backing_threads; ++idx_thread) {
-            klog_platform_thread_create(&g_klog_state.b_threads[idx_thread], klog_thread_body, NULL);
-        }
-    }
+    /* Need to initialize all of our mutexes before the thread starts and tries to use them */
     g_klog_state.p_mutex_deinitialize       = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
     g_klog_state.p_mutex_formatted_messages = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
     g_klog_state.p_mutex_file               = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
@@ -194,6 +202,12 @@ void klog_initialize(
     klog_platform_mutex_initialize(g_klog_state.p_mutex_formatted_messages);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_file);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_console);
+    if (g_klog_config.async.number_backing_threads > 0) {
+        g_klog_state.b_threads = g_klog_config.alloc.alloc_cb(sizeof(kpl_thread_t) * g_klog_config.async.number_backing_threads);
+        for (uint32_t idx_thread = 0; idx_thread < g_klog_config.async.number_backing_threads; ++idx_thread) {
+            klog_platform_thread_create(&g_klog_state.b_threads[idx_thread], klog_thread_body, NULL);
+        }
+    }
 
     g_klog_state.is_initialized = true;
 #endif
@@ -212,6 +226,26 @@ void klog_deinitialize(
     klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
     g_klog_state.is_initialized = false;
     klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
+
+    if (g_klog_state.b_threads) {
+        for (uint32_t idx_thread = 0; idx_thread < g_klog_config.async.number_backing_threads; ++idx_thread) {
+            klog_platform_thread_join(&g_klog_state.b_threads[idx_thread], NULL);
+        }
+        g_klog_config.alloc.free_cb(g_klog_state.b_threads);
+    }
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_deinitialize);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_formatted_messages);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_file);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_console);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_deinitialize);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_formatted_messages);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_file);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_console);
+    g_klog_state.b_threads                  = NULL;
+    g_klog_state.p_mutex_deinitialize       = NULL;
+    g_klog_state.p_mutex_formatted_messages = NULL;
+    g_klog_state.p_mutex_file               = NULL;
+    g_klog_state.p_mutex_console            = NULL;
 
     g_klog_state.number_loggers_max     = 0;
     g_klog_state.number_loggers_created = 0;
@@ -255,26 +289,6 @@ void klog_deinitialize(
         fclose(g_klog_state.p_file);
         g_klog_state.p_file = NULL;
     }
-
-    if (g_klog_state.b_threads) {
-        for (uint32_t idx_thread = 0; idx_thread < g_klog_config.async.number_backing_threads; ++idx_thread) {
-            klog_platform_thread_join(&g_klog_state.b_threads[idx_thread], NULL);
-        }
-        g_klog_config.alloc.free_cb(g_klog_state.b_threads);
-    }
-    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_deinitialize);
-    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_formatted_messages);
-    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_file);
-    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_console);
-    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_deinitialize);
-    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_formatted_messages);
-    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_file);
-    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_console);
-    g_klog_state.b_threads                  = NULL;
-    g_klog_state.p_mutex_deinitialize       = NULL;
-    g_klog_state.p_mutex_formatted_messages = NULL;
-    g_klog_state.p_mutex_file               = NULL;
-    g_klog_state.p_mutex_console            = NULL;
 
     /* Need to do this near the end because we need the callbacks for freeing */
     g_klog_config = (struct KlogConfig) { 0 };

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -292,9 +292,8 @@ void klog_initialize(
         * g_klog_state.message_element_count
     );
 
-    g_klog_state.p_file = klog_initialize_file(p_klog_file_info, g_klog_config.alloc.alloc_cb);
-    kdprintf("p_file: %p\n",             (void*)g_klog_state.p_file);
-    kdprintf("File max verbosity: %d\n", g_klog_config.file.max_level);
+    g_klog_state.filename_string = klog_format_filename(p_klog_file_info, g_klog_config.alloc.alloc_cb, g_klog_config.alloc.free_cb);
+    g_klog_state.p_file          = klog_initialize_file(g_klog_state.filename_string);
 
     g_klog_state.p_mutex_deinitialize = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
     g_klog_state.p_mutex_shared       = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
@@ -410,6 +409,10 @@ void klog_deinitialize(
     g_klog_config.alloc.free_cb(g_klog_state.b_message_levels);
     g_klog_state.b_message_levels = NULL;
 
+    if (g_klog_state.filename_string) {
+        g_klog_config.alloc.free_cb(g_klog_state.filename_string);
+        g_klog_state.filename_string = NULL;
+    }
     if (g_klog_state.p_file) {
         fclose(g_klog_state.p_file);
         g_klog_state.p_file = NULL;

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -25,44 +25,24 @@ void klog_consume(
     void
 ) {
     /* Only one consumer may be in here at a time - so we can wait for the unconsumed count to STRICTLY INCREASE */
-    klog_platform_mutex_lock(g_klog_state.p_mutex_hot_consumer);
+    /* printf("Consumer acquiring consumer\n"); */
+    /* klog_platform_mutex_lock(g_klog_state.p_mutex_consumer); */
 
 #if true
-    klog_platform_mutex_lock(g_klog_state.p_mutex_hot_shared);
-    if (g_klog_state.message_unconsumed_count == 0) {
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared);
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_consumer);
-        return;
-    }
+    /* @todo We will hang forever here if the producing thread is trying to deinitialize and never signals that we need to stop */
+    const int semval_full = klog_platform_semaphore_value_get(g_klog_state.p_semaphore_messages_full);
+    printf("Consumer waiting for the full semaphore with value: %d\n", semval_full);
+    klog_platform_semaphore_wait(g_klog_state.p_semaphore_messages_full);
+    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
 #else
-    /* Wait for a producer to produce a message */
-    while (true) {
-        klog_platform_mutex_lock(g_klog_state.p_mutex_hot_shared);
-        if (g_klog_state.message_unconsumed_count > 0) {
-            /* klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared); */
-            break;
-        }
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared);
-        sleep_usec(100);
+    printf("Consumer acquiring shared\n");
+    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
+    if (g_klog_state.message_unconsumed_count == 0) {
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_consumer);
+        return;
     }
 #endif
-
-    /* Acquire the shared mutex now that we have something to consume */
-    /* klog_platform_mutex_lock(g_klog_state.p_mutex_hot_shared); */
-
-    /*
-     *    printf(
-     *     "Consuming message %04d - index %02d (%02d unconsumed messages)\n",
-     *     TOTAL_CONSUMED_COUNT,
-     *     g_klog_state.message_element_consumer_idx,
-     *     g_klog_state.message_unconsumed_count
-     *    );
-     */
-
-    if (g_klog_state.message_unconsumed_count < 1) {
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared);
-        return;
-    }
 
     /* Get the level from the global buffer of levels corresponding to messages */
     const enum KlogLevel requested_level = g_klog_state.b_message_levels[g_klog_state.message_element_consumer_idx];
@@ -121,11 +101,13 @@ void klog_consume(
     }
     TOTAL_CONSUMED_COUNT++;
     g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count - 1;
-    /* printf("%d unconsumed messages remaining\n", g_klog_state.message_unconsumed_count); */
+    const int semval_empty                = klog_platform_semaphore_value_get(g_klog_state.p_semaphore_messages_empty);
+    printf("Consumer signalling the empty semaphore with value: %d\n", semval_empty);
+    klog_platform_semaphore_signal(g_klog_state.p_semaphore_messages_empty);
 
     /* Release the mutex */
-    klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared);
-    klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_consumer);
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
+    /* klog_platform_mutex_unlock(g_klog_state.p_mutex_consumer); */
 }
 
 void* klog_thread_body(
@@ -133,8 +115,12 @@ void* klog_thread_body(
 ) {
     (void)p;
 
+    printf("Starting thread body\n");
+
     while (true) {
+        /* @todo we should use a condition variable or something here to denote that we stopped???? */
         /* Check if we should break from the loop */
+        printf("Thread body acquiring deinit lock\n");
         klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
         if (!g_klog_state.is_initialized) {
             klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
@@ -143,7 +129,9 @@ void* klog_thread_body(
         klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
 
         /* Acquire the formatted message mutex and invoke the "consnuming function" */
+        printf("Thread body invoking consume\n");
         klog_consume();
+        sleep_usec(100);
     }
 
     return NULL;
@@ -320,15 +308,20 @@ void klog_initialize(
     kdprintf("p_file: %p\n",             (void*)g_klog_state.p_file);
     kdprintf("File max verbosity: %d\n", g_klog_config.file.max_level);
 
-    /* Need to initialize all of our mutexes before the thread starts and tries to use them */
     g_klog_state.p_mutex_deinitialize = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
-    g_klog_state.p_mutex_hot_shared   = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
-    g_klog_state.p_mutex_hot_producer = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
-    g_klog_state.p_mutex_hot_consumer = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
+    g_klog_state.p_mutex_shared       = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
+    g_klog_state.p_mutex_producer     = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
+    g_klog_state.p_mutex_consumer     = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
     klog_platform_mutex_initialize(g_klog_state.p_mutex_deinitialize);
-    klog_platform_mutex_initialize(g_klog_state.p_mutex_hot_shared);
-    klog_platform_mutex_initialize(g_klog_state.p_mutex_hot_producer);
-    klog_platform_mutex_initialize(g_klog_state.p_mutex_hot_consumer);
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_shared);
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_producer);
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_consumer);
+
+    g_klog_state.p_semaphore_messages_empty = g_klog_config.alloc.alloc_cb(sizeof(kpl_semaphore_t));
+    g_klog_state.p_semaphore_messages_full  = g_klog_config.alloc.alloc_cb(sizeof(kpl_semaphore_t));
+    klog_platform_semaphore_initialize(g_klog_state.p_semaphore_messages_empty, g_klog_state.message_element_count);
+    klog_platform_semaphore_initialize(g_klog_state.p_semaphore_messages_full,  0);
+
     if (g_klog_config.async.number_backing_threads > 0) {
         g_klog_state.b_threads = g_klog_config.alloc.alloc_cb(sizeof(kpl_thread_t) * g_klog_config.async.number_backing_threads);
         for (uint32_t idx_thread = 0; idx_thread < g_klog_config.async.number_backing_threads; ++idx_thread) {
@@ -351,17 +344,30 @@ void klog_deinitialize(
     }
 
     /* Wait for all messages to be consumed */
+# if true
     /* printf("Waiting for all messages to be consumed\n"); */
     while (true) {
-        klog_platform_mutex_lock(g_klog_state.p_mutex_hot_shared);
-        if (g_klog_state.message_unconsumed_count == 0) {
-            klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared);
+        const int semval_empty = klog_platform_semaphore_value_get(g_klog_state.p_semaphore_messages_empty);
+        printf("Deinitialization waiting for the empty semaphore with value: %d\n", semval_empty);
+        if (semval_empty == 0) {
             break;
         }
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared);
         sleep_usec(100);
     }
+    printf("Deinitialization sees that we are empty\n");
+# else
+    while (true) {
+        klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
+        if (g_klog_state.message_unconsumed_count == 0) {
+            klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
+            break;
+        }
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
+        sleep_usec(100);
+    }
+# endif
 
+    printf("Deinitialization function acquiring deinit lock\n");
     klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
     g_klog_state.is_initialized = false;
     klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
@@ -373,18 +379,25 @@ void klog_deinitialize(
         g_klog_config.alloc.free_cb(g_klog_state.b_threads);
     }
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_deinitialize);
-    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_hot_shared);
-    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_hot_producer);
-    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_hot_consumer);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_shared);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_producer);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_consumer);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_deinitialize);
-    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_hot_shared);
-    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_hot_producer);
-    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_hot_consumer);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_shared);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_producer);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_consumer);
     g_klog_state.b_threads            = NULL;
     g_klog_state.p_mutex_deinitialize = NULL;
-    g_klog_state.p_mutex_hot_shared   = NULL;
-    g_klog_state.p_mutex_hot_producer = NULL;
-    g_klog_state.p_mutex_hot_consumer = NULL;
+    g_klog_state.p_mutex_shared       = NULL;
+    g_klog_state.p_mutex_producer     = NULL;
+    g_klog_state.p_mutex_consumer     = NULL;
+
+    klog_platform_semaphore_deinitialize(g_klog_state.p_semaphore_messages_empty);
+    klog_platform_semaphore_deinitialize(g_klog_state.p_semaphore_messages_full);
+    g_klog_config.alloc.free_cb(g_klog_state.p_semaphore_messages_empty);
+    g_klog_config.alloc.free_cb(g_klog_state.p_semaphore_messages_full);
+    g_klog_state.p_semaphore_messages_empty = NULL;
+    g_klog_state.p_semaphore_messages_full  = NULL;
 
     g_klog_state.number_loggers_max     = 0;
     g_klog_state.number_loggers_created = 0;
@@ -562,30 +575,27 @@ void klog_log(
     }
 
     /* Only one producer may be in here at a time - so we can wait for the unconsumed count to STRICTLY DECREASE */
-    klog_platform_mutex_lock(g_klog_state.p_mutex_hot_producer);
+    /* printf("Producer acquiring producer\n"); */
+    /* klog_platform_mutex_lock(g_klog_state.p_mutex_producer); */
 
-    /* Wait for a consumer to consume a message and free up a message slot */
+    /* Wait for a consumer to consume a message and free up a message slot. We need at least one free spot */
+# if true
+    const int semval_empty = klog_platform_semaphore_value_get(g_klog_state.p_semaphore_messages_empty);
+    printf("Producer waiting for the empty semaphore with value: %d\n", semval_empty);
+    klog_platform_semaphore_wait(g_klog_state.p_semaphore_messages_empty);
+    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
+# else
     while (true) {
-        klog_platform_mutex_lock(g_klog_state.p_mutex_hot_shared);
+        printf("Producer acquiring shared\n");
+        klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
         if (g_klog_state.message_unconsumed_count < g_klog_state.message_element_count) {
-            /* klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared); */
             break;
         }
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared);
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
         sleep_usec(100);
     }
-
-    /*
-     *    printf(
-     *     "Producing message %04d - index %02d (%02d unconsumed messages)\n",
-     *     TOTAL_PRODUCED_COUNT,
-     *     g_klog_state.message_element_producer_idx,
-     *     g_klog_state.message_unconsumed_count
-     *    );
-     */
-
-    /* Now we know that the unconsumed count is valid for production, and has not gone up since it has gone down BECAUSE WE ARE THE ONLY PRODUCER IN HERE */
-    /* klog_platform_mutex_lock(g_klog_state.p_mutex_hot_shared); */
+# endif
+    /* Keep the lock as we continue through the rest of this */
 
     /* We are getting the time first, so it's closest to the actual point of invocation */
     char* s_prefix_time = g_klog_state.b_prefixes_time + (g_klog_state.message_element_producer_idx * g_klog_state.prefix_time_size);
@@ -677,9 +687,12 @@ void klog_log(
         printf("PRODUCED TOO MANY MESSAGES - HOW????\n");
         exit(1);
     }
+    const int semval_full = klog_platform_semaphore_value_get(g_klog_state.p_semaphore_messages_full);
+    printf("Producer signalling the full semaphore with value: %d\n", semval_full);
+    klog_platform_semaphore_signal(g_klog_state.p_semaphore_messages_full);
 
-    klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared);
-    klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_producer);
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
+    /* klog_platform_mutex_unlock(g_klog_state.p_mutex_producer); */
 
     /* @todo if no backing threads, invoke consuming function directly, else return */
 

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -16,7 +16,26 @@
 #include "./klog_output.h"
 #include "./klog_format.h"
 
-/* @todo Make this an actual function somewhere appropriate */
+/* @todo Make these actual functions somewhere appropriate */
+/* ====================================================================================================================================== */
+
+void klog_consume(
+    void
+) {
+    /* Acquire the mutex */
+    /* Get the formatted message from the message buffer */
+    /* If logging to console */ {
+        /* Get the console prefix */
+        /* Log to console */
+    }
+    /* If logging to file */ {
+        /* Get the file prefix */
+        /* Log to file */
+    }
+    /* Increment the consuming index */
+    /* Release the mutex */
+}
+
 void* klog_thread_body(
     void* p
 ) {
@@ -36,6 +55,8 @@ void* klog_thread_body(
 
     return NULL;
 }
+
+/* ====================================================================================================================================== */
 
 void klog_initialize(
     const uint32_t               max_number_loggers,
@@ -143,9 +164,9 @@ void klog_initialize(
         g_klog_config.console.use_color,
         g_klog_config.format.source_location_filename_max_length
     );
-    g_klog_state.prefix_time_size            = G_klog_time_string_length;
-    g_klog_state.prefix_source_location_size = g_klog_config.format.source_location_filename_max_length + 4 + 1; /* 4 digit line number, colon */
-    g_klog_state.message_element_idx         = 0;
+    g_klog_state.prefix_time_size             = G_klog_time_string_length;
+    g_klog_state.prefix_source_location_size  = g_klog_config.format.source_location_filename_max_length + 4 + 1; /* 4 digit line number, colon */
+    g_klog_state.message_element_producer_idx = 0;
     if (p_klog_async_info) {
         g_klog_state.message_element_count = p_klog_async_info->message_queue_number_elements;
     } else {
@@ -262,8 +283,8 @@ void klog_deinitialize(
     g_klog_state.b_level_strings         = NULL;
     g_klog_state.b_level_strings_colored = NULL;
 
-    g_klog_state.message_element_idx   = 0;
-    g_klog_state.message_element_count = 0;
+    g_klog_state.message_element_producer_idx = 0;
+    g_klog_state.message_element_count        = 0;
 
     g_klog_state.prefix_file_size = 0;
     g_klog_config.alloc.free_cb(g_klog_state.b_prefixes_file);
@@ -416,13 +437,13 @@ void klog_log(
     }
 
     /* We are getting the time first, so it's closest to the actual point of invocation */
-    char* s_prefix_time = g_klog_state.b_prefixes_time + (g_klog_state.message_element_idx * g_klog_state.prefix_time_size);
+    char* s_prefix_time = g_klog_state.b_prefixes_time + (g_klog_state.message_element_producer_idx * g_klog_state.prefix_time_size);
     memset(s_prefix_time, '\0', g_klog_state.prefix_time_size);
     const KlogString packed_time = g_klog_config.format.use_timestamp ? klog_format_time(s_prefix_time) : (KlogString) { 0, NULL };
 
     /* Create the input string with the arguments injected - including space for null termination */
     char* s_message_formatted = g_klog_state.b_messages_formatted
-        + (g_klog_state.message_element_idx * g_klog_state.message_formatted_max_size);
+        + (g_klog_state.message_element_producer_idx * g_klog_state.message_formatted_max_size);
     va_list p_args;
     va_start(p_args, s_format);
     const uint32_t actual_message_length = klog_format_input_message(
@@ -447,7 +468,7 @@ void klog_log(
     const KlogString* const p_packed_level_console = g_klog_config.console.use_color ? &packed_level_color : &packed_level_file;
 
     char* s_prefix_source_location = g_klog_state.b_prefixes_source_location
-        + (g_klog_state.message_element_idx * g_klog_state.prefix_source_location_size);
+        + (g_klog_state.message_element_producer_idx * g_klog_state.prefix_source_location_size);
     const KlogString packed_source_location = (g_klog_config.format.source_location_filename_max_length && s_filename)
         ? klog_format_source_location(
                 s_prefix_source_location,
@@ -458,8 +479,9 @@ void klog_log(
         : (KlogString) { 0, NULL };
 
     /* Get the pointers to the prefix buffers and reset them in preparation for setting */
-    char* s_prefix_file    = g_klog_state.b_prefixes_file + (g_klog_state.message_element_idx * g_klog_state.prefix_file_size);
-    char* s_prefix_console = g_klog_state.b_prefixes_console + (g_klog_state.message_element_idx * g_klog_state.prefix_console_size);
+    char* s_prefix_file    = g_klog_state.b_prefixes_file + (g_klog_state.message_element_producer_idx * g_klog_state.prefix_file_size);
+    char* s_prefix_console = g_klog_state.b_prefixes_console
+        + (g_klog_state.message_element_producer_idx * g_klog_state.prefix_console_size);
     memset(s_prefix_file,    '\0', g_klog_state.prefix_file_size);
     memset(s_prefix_console, '\0', g_klog_state.prefix_console_size);
 
@@ -501,9 +523,9 @@ void klog_log(
     }
 
     /* Update the index into our ring buffer */
-    g_klog_state.message_element_idx = g_klog_state.message_element_idx + 1;
-    if (g_klog_state.message_element_idx >= g_klog_state.message_element_count) {
-        g_klog_state.message_element_idx = 0;
+    g_klog_state.message_element_producer_idx = g_klog_state.message_element_producer_idx + 1;
+    if (g_klog_state.message_element_producer_idx >= g_klog_state.message_element_count) {
+        g_klog_state.message_element_producer_idx = 0;
     }
 
     /* Clear the buffer for the next time it is used - we also re-set the null terminator at the end of the actual message */

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -30,17 +30,15 @@ void klog_consume(
         return;
     }
 
-    /* @todo Get this from the global buffer of levels */
-    const enum KlogLevel requested_level = KLOG_LEVEL_TRACE;
-
-    /* @todo Get this length correctly */
-    /* Do we need an additional buffer to set this properly??? */
-    /* Should we use strlen to get this??? This implies the message is null terminated after formatting */
-    const uint32_t actual_message_length = 0;
+    /* Get the level from the global buffer of levels corresponding to messages */
+    const enum KlogLevel requested_level = g_klog_state.b_message_levels[g_klog_state.message_element_consumer_idx];
 
     /* Get the formatted message from the message buffer */
     char* s_message_formatted = g_klog_state.b_messages_formatted
         + (g_klog_state.message_element_consumer_idx * g_klog_state.message_formatted_max_size);
+
+    /* @todo Do we need an additional buffer denoting lengths, for speed up so we don't have to use strlen? */
+    const uint32_t actual_message_length = strlen(s_message_formatted);
 
     /* Get the console and file prefixes */
     char* s_prefix_file    = g_klog_state.b_prefixes_file + (g_klog_state.message_element_consumer_idx * g_klog_state.prefix_file_size);
@@ -67,7 +65,7 @@ void klog_consume(
         i_starting_character = i_starting_character + submessage_length + 1;
     }
 
-    /* Clear the buffer for the formatted message we just used */
+    /* Clear the message buffer for the formatted message we just used */
     memset(s_message_formatted, 0, g_klog_state.message_formatted_max_size);
 
     /* Update the consumer's index into our ring buffer */
@@ -258,6 +256,17 @@ void klog_initialize(
         g_klog_config.alloc.alloc_cb
     );
 
+    g_klog_state.b_message_levels = g_klog_config.alloc.alloc_cb(
+        sizeof(*g_klog_state.b_message_levels)
+        * g_klog_state.message_element_count
+    );
+    memset(
+        g_klog_state.b_message_levels,
+        0,
+        sizeof(*g_klog_state.b_message_levels)
+        * g_klog_state.message_element_count
+    );
+
     g_klog_state.p_file = klog_initialize_file(p_klog_file_info, g_klog_config.alloc.alloc_cb);
     kdprintf("p_file: %p\n",             (void*)g_klog_state.p_file);
     kdprintf("File max verbosity: %d\n", g_klog_config.file.max_level);
@@ -355,6 +364,9 @@ void klog_deinitialize(
     g_klog_state.message_formatted_max_size = 0;
     g_klog_config.alloc.free_cb(g_klog_state.b_messages_formatted);
     g_klog_state.b_messages_formatted = NULL;
+
+    g_klog_config.alloc.free_cb(g_klog_state.b_message_levels);
+    g_klog_state.b_message_levels = NULL;
 
     if (g_klog_state.p_file) {
         fclose(g_klog_state.p_file);
@@ -555,6 +567,9 @@ void klog_log(
         &packed_source_location
     );
 
+    /* Update the level buffer */
+    g_klog_state.b_message_levels[g_klog_state.message_element_producer_idx] = requested_level;
+
     /* Update the producer's index into our ring buffer */
     g_klog_state.message_element_producer_idx = g_klog_state.message_element_producer_idx + 1;
     if (g_klog_state.message_element_producer_idx >= g_klog_state.message_element_count) {
@@ -569,6 +584,12 @@ void klog_log(
 
     /* @todo if no backing threads, invoke consuming function directly, else return */
 
+# if true
+    (void)actual_message_length;
+    (void)packed_prefix_file;
+    (void)packed_prefix_console;
+    klog_consume();
+# else
     /* Actually log the message */
     uint32_t i_starting_character = 0;
     while (i_starting_character <= actual_message_length) {
@@ -596,5 +617,6 @@ void klog_log(
 
     /* Clear the buffer for the next time it is used - we also re-set the null terminator at the end of the actual message */
     memset(s_message_formatted, 0, g_klog_state.message_formatted_max_size);
+# endif
 #endif
 }

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -19,30 +19,28 @@
 /* @todo Make these actual functions somewhere appropriate */
 /* ====================================================================================================================================== */
 
-uint32_t TOTAL_CONSUMED_COUNT = 0;
-
-void klog_consume(
+bool klog_consume(
     void
 ) {
-    /* Only one consumer may be in here at a time - so we can wait for the unconsumed count to STRICTLY INCREASE */
-    /* printf("Consumer acquiring consumer\n"); */
-    /* klog_platform_mutex_lock(g_klog_state.p_mutex_consumer); */
+    klog_platform_mutex_lock(g_klog_state.p_mutex_consumer);
 
-#if true
-    /* @todo We will hang forever here if the producing thread is trying to deinitialize and never signals that we need to stop */
-    const int semval_full = klog_platform_semaphore_value_get(g_klog_state.p_semaphore_messages_full);
-    printf("Consumer waiting for the full semaphore with value: %d\n", semval_full);
     klog_platform_semaphore_wait(g_klog_state.p_semaphore_messages_full);
+
     klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
-#else
-    printf("Consumer acquiring shared\n");
-    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
-    if (g_klog_state.message_unconsumed_count == 0) {
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_consumer);
-        return;
+
+    if (g_klog_state.message_produced_total_count == g_klog_state.message_consumed_total_count) {
+        /* We have logged everything we should have - up to this point. Should we stop?? */
+        klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
+
+        if (!g_klog_state.is_initialized) {
+            /* We should stop */
+            klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
+            return true;
+        }
+
+        /* Let's keep going */
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
     }
-#endif
 
     /* Get the level from the global buffer of levels corresponding to messages */
     const enum KlogLevel requested_level = g_klog_state.b_message_levels[g_klog_state.message_element_consumer_idx];
@@ -60,13 +58,13 @@ void klog_consume(
         + (g_klog_state.message_element_consumer_idx * g_klog_state.prefix_console_size);
     const KlogString packed_prefix_file    = { g_klog_state.prefix_file_size, s_prefix_file };
     const KlogString packed_prefix_console = { g_klog_state.prefix_console_size, s_prefix_console };
-    printf(
-        "USING     console prefix at index %02d = %p : \"%.*s\"\n",
-        g_klog_state.message_element_consumer_idx,
-        (void*)s_prefix_console,
-        g_klog_state.prefix_console_size,
-        s_prefix_console
-    );
+    /* printf( */
+    /*     "USING     console prefix at index %02d = %p : \"%.*s\"\n", */
+    /*     g_klog_state.message_element_consumer_idx, */
+    /*     (void*)s_prefix_console, */
+    /*     g_klog_state.prefix_console_size, */
+    /*     s_prefix_console */
+    /* ); */
 
     uint32_t i_starting_character = 0;
     while (i_starting_character <= actual_message_length) {
@@ -78,7 +76,7 @@ void klog_consume(
         const KlogString packed_message = { submessage_length, s_message_formatted + i_starting_character };
         if (requested_level <= g_klog_config.console.max_level) {
             (void)packed_prefix_console;
-            /* klog_output_console(&packed_prefix_console, &packed_message); */
+            klog_output_console(&packed_prefix_console, &packed_message);
         }
         if (g_klog_state.p_file && (requested_level <= g_klog_config.file.max_level)) {
             klog_output_file(g_klog_state.p_file, &packed_prefix_file, &packed_message);
@@ -88,6 +86,7 @@ void klog_consume(
     }
 
     /* Clear the message buffer for the formatted message we just used */
+    /* @todo We shouldn't do this here - this should be done in the producer so we don't need to worry about staying sync-ed after outputting */
     memset(s_message_formatted, 0, g_klog_state.message_formatted_max_size);
 
     /* Update the consumer's index into our ring buffer */
@@ -98,16 +97,18 @@ void klog_consume(
 
     if (g_klog_state.message_unconsumed_count < 1) {
         printf("CONSUMED TOO MANY MESSAGES - HOW????\n");
+        exit(1);
     }
-    TOTAL_CONSUMED_COUNT++;
+    g_klog_state.message_consumed_total_count++;
     g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count - 1;
-    const int semval_empty                = klog_platform_semaphore_value_get(g_klog_state.p_semaphore_messages_empty);
-    printf("Consumer signalling the empty semaphore with value: %d\n", semval_empty);
+
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
+
     klog_platform_semaphore_signal(g_klog_state.p_semaphore_messages_empty);
 
-    /* Release the mutex */
-    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
-    /* klog_platform_mutex_unlock(g_klog_state.p_mutex_consumer); */
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_consumer);
+
+    return false;
 }
 
 void* klog_thread_body(
@@ -115,23 +116,12 @@ void* klog_thread_body(
 ) {
     (void)p;
 
-    printf("Starting thread body\n");
-
     while (true) {
-        /* @todo we should use a condition variable or something here to denote that we stopped???? */
-        /* Check if we should break from the loop */
-        printf("Thread body acquiring deinit lock\n");
-        klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
-        if (!g_klog_state.is_initialized) {
-            klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
+        /* Acquire the formatted message mutex and invoke the "consnuming function" and stop if we should */
+        bool should_stop = klog_consume();
+        if (should_stop) {
             break;
         }
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
-
-        /* Acquire the formatted message mutex and invoke the "consnuming function" */
-        printf("Thread body invoking consume\n");
-        klog_consume();
-        sleep_usec(100);
     }
 
     return NULL;
@@ -168,6 +158,8 @@ void klog_initialize(
     ) {
         exit(KLOG_EXIT_CODE);
     }
+
+    g_klog_state.is_initialized = true; /* Set this upfront (before threads) so they don't hang while waiting for it */
 
     g_klog_config.format = klog_format_info;
     if (p_klog_async_info) {
@@ -250,6 +242,8 @@ void klog_initialize(
     g_klog_state.message_unconsumed_count     = 0;
     g_klog_state.message_element_producer_idx = 0;
     g_klog_state.message_element_consumer_idx = 0;
+    g_klog_state.message_produced_total_count = 0;
+    g_klog_state.message_consumed_total_count = 0;
     if (p_klog_async_info) {
         g_klog_state.message_element_count = p_klog_async_info->message_queue_number_elements;
     } else {
@@ -328,8 +322,6 @@ void klog_initialize(
             klog_platform_thread_create(&g_klog_state.b_threads[idx_thread], klog_thread_body, NULL);
         }
     }
-
-    g_klog_state.is_initialized = true;
 #endif
 }
 
@@ -338,38 +330,18 @@ void klog_deinitialize(
 ) {
 #ifdef KLOG_OFF
 #else
+    klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
     if (!g_klog_state.is_initialized) {
         kdprintf("Trying to de-initialize klog, when it is not yet initialized\n");
         exit(KLOG_EXIT_CODE);
     }
 
-    /* Wait for all messages to be consumed */
-# if true
-    /* printf("Waiting for all messages to be consumed\n"); */
-    while (true) {
-        const int semval_empty = klog_platform_semaphore_value_get(g_klog_state.p_semaphore_messages_empty);
-        printf("Deinitialization waiting for the empty semaphore with value: %d\n", semval_empty);
-        if (semval_empty == 0) {
-            break;
-        }
-        sleep_usec(100);
-    }
-    printf("Deinitialization sees that we are empty\n");
-# else
-    while (true) {
-        klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
-        if (g_klog_state.message_unconsumed_count == 0) {
-            klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
-            break;
-        }
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
-        sleep_usec(100);
-    }
-# endif
-
-    printf("Deinitialization function acquiring deinit lock\n");
-    klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
     g_klog_state.is_initialized = false;
+
+    /* Ensure each of the consumers goes through the semaphore wait, into the check */
+    for (uint32_t idx_consumer = 0; idx_consumer < g_klog_config.async.number_backing_threads; ++idx_consumer) {
+        klog_platform_semaphore_signal(g_klog_state.p_semaphore_messages_full);
+    }
     klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
 
     if (g_klog_state.b_threads) {
@@ -418,6 +390,8 @@ void klog_deinitialize(
     g_klog_state.message_element_producer_idx = 0;
     g_klog_state.message_element_consumer_idx = 0;
     g_klog_state.message_element_count        = 0;
+    g_klog_state.message_produced_total_count = 0;
+    g_klog_state.message_consumed_total_count = 0;
 
     g_klog_state.prefix_file_size = 0;
     g_klog_config.alloc.free_cb(g_klog_state.b_prefixes_file);
@@ -528,8 +502,6 @@ void klog_logger_level_set(
 #endif
 }
 
-uint32_t TOTAL_PRODUCED_COUNT = 0;
-
 void klog_log(
     const KlogLoggerHandle* const p_logger_handle,
     const enum KlogLevel          requested_level,
@@ -545,10 +517,14 @@ void klog_log(
     (void)line_number;
     (void)format;
 #else
+    klog_platform_mutex_lock(g_klog_state.p_mutex_producer);
+
+    klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
     if (!g_klog_state.is_initialized) {
         kdprintf("Trying to create klog logger, but klog is not initialized\n");
         exit(KLOG_EXIT_CODE);
     }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
 
     if (p_logger_handle->value >= g_klog_state.number_loggers_created) {
         kdprintf("Trying to log with logger %d, when only %d loggers exist\n", p_logger_handle->value, g_klog_state.number_loggers_created);
@@ -562,40 +538,24 @@ void klog_log(
 
     if (requested_level == 0) {
         kdprintf("Trying to log with the level set to OFF\n");
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_producer);
         return;
     }
     if ((requested_level > g_klog_config.console.max_level) && (requested_level > g_klog_config.file.max_level)) {
         kdprintf("Trying to log with a level that neither console nor file accept\n");
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_producer);
         return;
     }
 
     if (requested_level > g_klog_state.a_logger_levels[p_logger_handle->value]) {
         kdprintf("Trying to log with a level more verbose than the requested logger allows\n");
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_producer);
         return;
     }
 
-    /* Only one producer may be in here at a time - so we can wait for the unconsumed count to STRICTLY DECREASE */
-    /* printf("Producer acquiring producer\n"); */
-    /* klog_platform_mutex_lock(g_klog_state.p_mutex_producer); */
-
-    /* Wait for a consumer to consume a message and free up a message slot. We need at least one free spot */
-# if true
-    const int semval_empty = klog_platform_semaphore_value_get(g_klog_state.p_semaphore_messages_empty);
-    printf("Producer waiting for the empty semaphore with value: %d\n", semval_empty);
     klog_platform_semaphore_wait(g_klog_state.p_semaphore_messages_empty);
+
     klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
-# else
-    while (true) {
-        printf("Producer acquiring shared\n");
-        klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
-        if (g_klog_state.message_unconsumed_count < g_klog_state.message_element_count) {
-            break;
-        }
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
-        sleep_usec(100);
-    }
-# endif
-    /* Keep the lock as we continue through the rest of this */
 
     /* We are getting the time first, so it's closest to the actual point of invocation */
     char* s_prefix_time = g_klog_state.b_prefixes_time + (g_klog_state.message_element_producer_idx * g_klog_state.prefix_time_size);
@@ -663,13 +623,13 @@ void klog_log(
         p_packed_level_console,
         &packed_source_location
     );
-    printf(
-        "POPULATED console prefix at index %02d = %p : \"%.*s\"\n",
-        g_klog_state.message_element_producer_idx,
-        (void*)s_prefix_console,
-        g_klog_state.prefix_console_size,
-        s_prefix_console
-    );
+    /*  printf( */
+    /*      "POPULATED console prefix at index %02d = %p : \"%.*s\"\n", */
+    /*      g_klog_state.message_element_producer_idx, */
+    /*      (void*)s_prefix_console, */
+    /*      g_klog_state.prefix_console_size, */
+    /*      s_prefix_console */
+    /*  ); */
 
     /* Update the level buffer */
     g_klog_state.b_message_levels[g_klog_state.message_element_producer_idx] = requested_level;
@@ -681,22 +641,19 @@ void klog_log(
     }
 
     /* Let everyone know there is another message ready for consumption */
-    TOTAL_PRODUCED_COUNT++;
+    g_klog_state.message_produced_total_count++;
     g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count + 1;
     if (g_klog_state.message_unconsumed_count > g_klog_state.message_element_count) {
         printf("PRODUCED TOO MANY MESSAGES - HOW????\n");
         exit(1);
     }
-    const int semval_full = klog_platform_semaphore_value_get(g_klog_state.p_semaphore_messages_full);
-    printf("Producer signalling the full semaphore with value: %d\n", semval_full);
-    klog_platform_semaphore_signal(g_klog_state.p_semaphore_messages_full);
 
     klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
-    /* klog_platform_mutex_unlock(g_klog_state.p_mutex_producer); */
 
-    /* @todo if no backing threads, invoke consuming function directly, else return */
+    klog_platform_semaphore_signal(g_klog_state.p_semaphore_messages_full);
 
-# if true
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_producer);
+
     (void)actual_message_length;
     (void)packed_prefix_file;
     (void)packed_prefix_console;
@@ -706,34 +663,5 @@ void klog_log(
         return;
     }
     klog_consume();
-# else
-    /* Actually log the message */
-    uint32_t i_starting_character = 0;
-    while (i_starting_character <= actual_message_length) {
-        const char* const p_newline         = strchr(s_message_formatted + i_starting_character, '\n');
-        const uint32_t    submessage_length = p_newline
-            ? p_newline - (s_message_formatted + i_starting_character)
-            : actual_message_length;
-
-        const KlogString packed_message = { submessage_length, s_message_formatted + i_starting_character };
-        if (requested_level <= g_klog_config.console.max_level) {
-            klog_output_console(&packed_prefix_console, &packed_message);
-        }
-        if (g_klog_state.p_file && (requested_level <= g_klog_config.file.max_level)) {
-            klog_output_file(g_klog_state.p_file, &packed_prefix_file, &packed_message);
-        }
-
-        i_starting_character = i_starting_character + submessage_length + 1;
-    }
-
-    /* Update the consumer's index into our ring buffer */
-    g_klog_state.message_element_consumer_idx = g_klog_state.message_element_consumer_idx + 1;
-    if (g_klog_state.message_element_consumer_idx >= g_klog_state.message_element_count) {
-        g_klog_state.message_element_consumer_idx = 0;
-    }
-
-    /* Clear the buffer for the next time it is used - we also re-set the null terminator at the end of the actual message */
-    memset(s_message_formatted, 0, g_klog_state.message_formatted_max_size);
-# endif
 #endif
 }

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -34,7 +34,6 @@ void klog_consume(
         klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_consumer);
         return;
     }
-
 #else
     /* Wait for a producer to produce a message */
     while (true) {
@@ -81,6 +80,13 @@ void klog_consume(
         + (g_klog_state.message_element_consumer_idx * g_klog_state.prefix_console_size);
     const KlogString packed_prefix_file    = { g_klog_state.prefix_file_size, s_prefix_file };
     const KlogString packed_prefix_console = { g_klog_state.prefix_console_size, s_prefix_console };
+    printf(
+        "USING     console prefix at index %02d = %p : \"%.*s\"\n",
+        g_klog_state.message_element_consumer_idx,
+        (void*)s_prefix_console,
+        g_klog_state.prefix_console_size,
+        s_prefix_console
+    );
 
     uint32_t i_starting_character = 0;
     while (i_starting_character <= actual_message_length) {
@@ -91,7 +97,8 @@ void klog_consume(
 
         const KlogString packed_message = { submessage_length, s_message_formatted + i_starting_character };
         if (requested_level <= g_klog_config.console.max_level) {
-            klog_output_console(&packed_prefix_console, &packed_message);
+            (void)packed_prefix_console;
+            /* klog_output_console(&packed_prefix_console, &packed_message); */
         }
         if (g_klog_state.p_file && (requested_level <= g_klog_config.file.max_level)) {
             klog_output_file(g_klog_state.p_file, &packed_prefix_file, &packed_message);
@@ -645,6 +652,13 @@ void klog_log(
         &packed_name,
         p_packed_level_console,
         &packed_source_location
+    );
+    printf(
+        "POPULATED console prefix at index %02d = %p : \"%.*s\"\n",
+        g_klog_state.message_element_producer_idx,
+        (void*)s_prefix_console,
+        g_klog_state.prefix_console_size,
+        s_prefix_console
     );
 
     /* Update the level buffer */

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -16,6 +16,14 @@
 #include "./klog_output.h"
 #include "./klog_format.h"
 
+/* @todo Make this an actual function somewhere appropriate */
+void* klog_thread_body(
+    void* p
+) {
+    (void)p;
+    return NULL;
+}
+
 void klog_initialize(
     const uint32_t               max_number_loggers,
     const KlogFormatInfo         klog_format_info,
@@ -172,6 +180,19 @@ void klog_initialize(
     kdprintf("p_file: %p\n",             (void*)g_klog_state.p_file);
     kdprintf("File max verbosity: %d\n", g_klog_config.file.max_level);
 
+    if (g_klog_config.async.number_backing_threads > 0) {
+        g_klog_state.b_threads = g_klog_config.alloc.alloc_cb(sizeof(kpl_thread_t) * g_klog_config.async.number_backing_threads);
+        for (uint32_t idx_thread = 0; idx_thread < g_klog_config.async.number_backing_threads; ++idx_thread) {
+            klog_platform_thread_create(&g_klog_state.b_threads[idx_thread], klog_thread_body, NULL);
+        }
+    }
+    g_klog_state.p_mutex_formatted_messages = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
+    g_klog_state.p_mutex_file               = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
+    g_klog_state.p_mutex_console            = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_formatted_messages);
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_file);
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_console);
+
     g_klog_state.is_initialized = true;
 #endif
 }
@@ -228,6 +249,23 @@ void klog_deinitialize(
         fclose(g_klog_state.p_file);
         g_klog_state.p_file = NULL;
     }
+
+    if (g_klog_state.b_threads) {
+        for (uint32_t idx_thread = 0; idx_thread < g_klog_config.async.number_backing_threads; ++idx_thread) {
+            klog_platform_thread_join(&g_klog_state.b_threads[idx_thread], NULL);
+        }
+        g_klog_config.alloc.free_cb(g_klog_state.b_threads);
+    }
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_formatted_messages);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_file);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_console);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_formatted_messages);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_file);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_console);
+    g_klog_state.b_threads                  = NULL;
+    g_klog_state.p_mutex_formatted_messages = NULL;
+    g_klog_state.p_mutex_file               = NULL;
+    g_klog_state.p_mutex_console            = NULL;
 
     /* Need to do this near the end because we need the callbacks for freeing */
     g_klog_config = (struct KlogConfig) { 0 };

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -186,9 +186,11 @@ void klog_initialize(
             klog_platform_thread_create(&g_klog_state.b_threads[idx_thread], klog_thread_body, NULL);
         }
     }
+    g_klog_state.p_mutex_deinitialize       = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
     g_klog_state.p_mutex_formatted_messages = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
     g_klog_state.p_mutex_file               = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
     g_klog_state.p_mutex_console            = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_deinitialize);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_formatted_messages);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_file);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_console);
@@ -206,6 +208,10 @@ void klog_deinitialize(
         kdprintf("Trying to de-initialize klog, when it is not yet initialized\n");
         exit(KLOG_EXIT_CODE);
     }
+
+    klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
+    g_klog_state.is_initialized = false;
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
 
     g_klog_state.number_loggers_max     = 0;
     g_klog_state.number_loggers_created = 0;
@@ -256,21 +262,22 @@ void klog_deinitialize(
         }
         g_klog_config.alloc.free_cb(g_klog_state.b_threads);
     }
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_deinitialize);
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_formatted_messages);
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_file);
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_console);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_deinitialize);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_formatted_messages);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_file);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_console);
     g_klog_state.b_threads                  = NULL;
+    g_klog_state.p_mutex_deinitialize       = NULL;
     g_klog_state.p_mutex_formatted_messages = NULL;
     g_klog_state.p_mutex_file               = NULL;
     g_klog_state.p_mutex_console            = NULL;
 
     /* Need to do this near the end because we need the callbacks for freeing */
     g_klog_config = (struct KlogConfig) { 0 };
-
-    g_klog_state.is_initialized = false;
 #endif
 }
 

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -35,6 +35,8 @@ bool klog_consume(
         if (!g_klog_state.is_initialized) {
             /* We should stop */
             klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
+            klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
+            klog_platform_mutex_unlock(g_klog_state.p_mutex_consumer);
             return true;
         }
 
@@ -58,13 +60,6 @@ bool klog_consume(
         + (g_klog_state.message_element_consumer_idx * g_klog_state.prefix_console_size);
     const KlogString packed_prefix_file    = { g_klog_state.prefix_file_size, s_prefix_file };
     const KlogString packed_prefix_console = { g_klog_state.prefix_console_size, s_prefix_console };
-    /* printf( */
-    /*     "USING     console prefix at index %02d = %p : \"%.*s\"\n", */
-    /*     g_klog_state.message_element_consumer_idx, */
-    /*     (void*)s_prefix_console, */
-    /*     g_klog_state.prefix_console_size, */
-    /*     s_prefix_console */
-    /* ); */
 
     uint32_t i_starting_character = 0;
     while (i_starting_character <= actual_message_length) {
@@ -75,7 +70,6 @@ bool klog_consume(
 
         const KlogString packed_message = { submessage_length, s_message_formatted + i_starting_character };
         if (requested_level <= g_klog_config.console.max_level) {
-            (void)packed_prefix_console;
             klog_output_console(&packed_prefix_console, &packed_message);
         }
         if (g_klog_state.p_file && (requested_level <= g_klog_config.file.max_level)) {
@@ -96,7 +90,7 @@ bool klog_consume(
     }
 
     if (g_klog_state.message_unconsumed_count < 1) {
-        printf("CONSUMED TOO MANY MESSAGES - HOW????\n");
+        kdprintf("klog_consume consumed too many messages\n");
         exit(1);
     }
     g_klog_state.message_consumed_total_count++;
@@ -623,13 +617,6 @@ void klog_log(
         p_packed_level_console,
         &packed_source_location
     );
-    /*  printf( */
-    /*      "POPULATED console prefix at index %02d = %p : \"%.*s\"\n", */
-    /*      g_klog_state.message_element_producer_idx, */
-    /*      (void*)s_prefix_console, */
-    /*      g_klog_state.prefix_console_size, */
-    /*      s_prefix_console */
-    /*  ); */
 
     /* Update the level buffer */
     g_klog_state.b_message_levels[g_klog_state.message_element_producer_idx] = requested_level;
@@ -644,7 +631,11 @@ void klog_log(
     g_klog_state.message_produced_total_count++;
     g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count + 1;
     if (g_klog_state.message_unconsumed_count > g_klog_state.message_element_count) {
-        printf("PRODUCED TOO MANY MESSAGES - HOW????\n");
+        kdprintf(
+            "klog_log produced too many messages (%d unconsumed messages when we only have space for %d)\n",
+            g_klog_state.message_unconsumed_count,
+            g_klog_state.message_element_count
+        );
         exit(1);
     }
 

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -19,14 +19,49 @@
 /* @todo Make these actual functions somewhere appropriate */
 /* ====================================================================================================================================== */
 
+uint32_t TOTAL_CONSUMED_COUNT = 0;
+
 void klog_consume(
     void
 ) {
-    /* Acquire the mutex */
-    klog_platform_mutex_lock(g_klog_state.p_mutex_formatted_messages);
+    /* Only one consumer may be in here at a time - so we can wait for the unconsumed count to STRICTLY INCREASE */
+    klog_platform_mutex_lock(g_klog_state.p_mutex_hot_consumer);
+
+#if true
+    klog_platform_mutex_lock(g_klog_state.p_mutex_hot_shared);
+    if (g_klog_state.message_unconsumed_count == 0) {
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared);
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_consumer);
+        return;
+    }
+
+#else
+    /* Wait for a producer to produce a message */
+    while (true) {
+        klog_platform_mutex_lock(g_klog_state.p_mutex_hot_shared);
+        if (g_klog_state.message_unconsumed_count > 0) {
+            /* klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared); */
+            break;
+        }
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared);
+        sleep_usec(100);
+    }
+#endif
+
+    /* Acquire the shared mutex now that we have something to consume */
+    /* klog_platform_mutex_lock(g_klog_state.p_mutex_hot_shared); */
+
+    /*
+     *    printf(
+     *     "Consuming message %04d - index %02d (%02d unconsumed messages)\n",
+     *     TOTAL_CONSUMED_COUNT,
+     *     g_klog_state.message_element_consumer_idx,
+     *     g_klog_state.message_unconsumed_count
+     *    );
+     */
 
     if (g_klog_state.message_unconsumed_count < 1) {
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_formatted_messages);
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared);
         return;
     }
 
@@ -74,10 +109,16 @@ void klog_consume(
         g_klog_state.message_element_consumer_idx = 0;
     }
 
+    if (g_klog_state.message_unconsumed_count < 1) {
+        printf("CONSUMED TOO MANY MESSAGES - HOW????\n");
+    }
+    TOTAL_CONSUMED_COUNT++;
     g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count - 1;
+    /* printf("%d unconsumed messages remaining\n", g_klog_state.message_unconsumed_count); */
 
     /* Release the mutex */
-    klog_platform_mutex_unlock(g_klog_state.p_mutex_formatted_messages);
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared);
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_consumer);
 }
 
 void* klog_thread_body(
@@ -95,6 +136,7 @@ void* klog_thread_body(
         klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
 
         /* Acquire the formatted message mutex and invoke the "consnuming function" */
+        klog_consume();
     }
 
     return NULL;
@@ -272,14 +314,14 @@ void klog_initialize(
     kdprintf("File max verbosity: %d\n", g_klog_config.file.max_level);
 
     /* Need to initialize all of our mutexes before the thread starts and tries to use them */
-    g_klog_state.p_mutex_deinitialize       = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
-    g_klog_state.p_mutex_formatted_messages = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
-    g_klog_state.p_mutex_file               = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
-    g_klog_state.p_mutex_console            = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
+    g_klog_state.p_mutex_deinitialize = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
+    g_klog_state.p_mutex_hot_shared   = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
+    g_klog_state.p_mutex_hot_producer = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
+    g_klog_state.p_mutex_hot_consumer = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
     klog_platform_mutex_initialize(g_klog_state.p_mutex_deinitialize);
-    klog_platform_mutex_initialize(g_klog_state.p_mutex_formatted_messages);
-    klog_platform_mutex_initialize(g_klog_state.p_mutex_file);
-    klog_platform_mutex_initialize(g_klog_state.p_mutex_console);
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_hot_shared);
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_hot_producer);
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_hot_consumer);
     if (g_klog_config.async.number_backing_threads > 0) {
         g_klog_state.b_threads = g_klog_config.alloc.alloc_cb(sizeof(kpl_thread_t) * g_klog_config.async.number_backing_threads);
         for (uint32_t idx_thread = 0; idx_thread < g_klog_config.async.number_backing_threads; ++idx_thread) {
@@ -301,6 +343,18 @@ void klog_deinitialize(
         exit(KLOG_EXIT_CODE);
     }
 
+    /* Wait for all messages to be consumed */
+    /* printf("Waiting for all messages to be consumed\n"); */
+    while (true) {
+        klog_platform_mutex_lock(g_klog_state.p_mutex_hot_shared);
+        if (g_klog_state.message_unconsumed_count == 0) {
+            klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared);
+            break;
+        }
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared);
+        sleep_usec(100);
+    }
+
     klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
     g_klog_state.is_initialized = false;
     klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
@@ -312,18 +366,18 @@ void klog_deinitialize(
         g_klog_config.alloc.free_cb(g_klog_state.b_threads);
     }
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_deinitialize);
-    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_formatted_messages);
-    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_file);
-    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_console);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_hot_shared);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_hot_producer);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_hot_consumer);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_deinitialize);
-    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_formatted_messages);
-    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_file);
-    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_console);
-    g_klog_state.b_threads                  = NULL;
-    g_klog_state.p_mutex_deinitialize       = NULL;
-    g_klog_state.p_mutex_formatted_messages = NULL;
-    g_klog_state.p_mutex_file               = NULL;
-    g_klog_state.p_mutex_console            = NULL;
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_hot_shared);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_hot_producer);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_hot_consumer);
+    g_klog_state.b_threads            = NULL;
+    g_klog_state.p_mutex_deinitialize = NULL;
+    g_klog_state.p_mutex_hot_shared   = NULL;
+    g_klog_state.p_mutex_hot_producer = NULL;
+    g_klog_state.p_mutex_hot_consumer = NULL;
 
     g_klog_state.number_loggers_max     = 0;
     g_klog_state.number_loggers_created = 0;
@@ -454,6 +508,8 @@ void klog_logger_level_set(
 #endif
 }
 
+uint32_t TOTAL_PRODUCED_COUNT = 0;
+
 void klog_log(
     const KlogLoggerHandle* const p_logger_handle,
     const enum KlogLevel          requested_level,
@@ -498,7 +554,31 @@ void klog_log(
         return;
     }
 
-    klog_platform_mutex_lock(g_klog_state.p_mutex_formatted_messages);
+    /* Only one producer may be in here at a time - so we can wait for the unconsumed count to STRICTLY DECREASE */
+    klog_platform_mutex_lock(g_klog_state.p_mutex_hot_producer);
+
+    /* Wait for a consumer to consume a message and free up a message slot */
+    while (true) {
+        klog_platform_mutex_lock(g_klog_state.p_mutex_hot_shared);
+        if (g_klog_state.message_unconsumed_count < g_klog_state.message_element_count) {
+            /* klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared); */
+            break;
+        }
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared);
+        sleep_usec(100);
+    }
+
+    /*
+     *    printf(
+     *     "Producing message %04d - index %02d (%02d unconsumed messages)\n",
+     *     TOTAL_PRODUCED_COUNT,
+     *     g_klog_state.message_element_producer_idx,
+     *     g_klog_state.message_unconsumed_count
+     *    );
+     */
+
+    /* Now we know that the unconsumed count is valid for production, and has not gone up since it has gone down BECAUSE WE ARE THE ONLY PRODUCER IN HERE */
+    /* klog_platform_mutex_lock(g_klog_state.p_mutex_hot_shared); */
 
     /* We are getting the time first, so it's closest to the actual point of invocation */
     char* s_prefix_time = g_klog_state.b_prefixes_time + (g_klog_state.message_element_producer_idx * g_klog_state.prefix_time_size);
@@ -577,10 +657,15 @@ void klog_log(
     }
 
     /* Let everyone know there is another message ready for consumption */
-    /* @todo Error out if we have gotten into a state not in accordance with our buffer full strategy? */
+    TOTAL_PRODUCED_COUNT++;
     g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count + 1;
+    if (g_klog_state.message_unconsumed_count > g_klog_state.message_element_count) {
+        printf("PRODUCED TOO MANY MESSAGES - HOW????\n");
+        exit(1);
+    }
 
-    klog_platform_mutex_unlock(g_klog_state.p_mutex_formatted_messages);
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_shared);
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_hot_producer);
 
     /* @todo if no backing threads, invoke consuming function directly, else return */
 
@@ -588,6 +673,11 @@ void klog_log(
     (void)actual_message_length;
     (void)packed_prefix_file;
     (void)packed_prefix_console;
+
+    /* If we have consumer threads, we're done here. Else, consume what we just made */
+    if (g_klog_config.async.number_backing_threads > 0) {
+        return;
+    }
     klog_consume();
 # else
     /* Actually log the message */

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -23,17 +23,63 @@ void klog_consume(
     void
 ) {
     /* Acquire the mutex */
+    klog_platform_mutex_lock(g_klog_state.p_mutex_formatted_messages);
+
+    if (g_klog_state.message_unconsumed_count < 1) {
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_formatted_messages);
+        return;
+    }
+
+    /* @todo Get this from the global buffer of levels */
+    const enum KlogLevel requested_level = KLOG_LEVEL_TRACE;
+
+    /* @todo Get this length correctly */
+    /* Do we need an additional buffer to set this properly??? */
+    /* Should we use strlen to get this??? This implies the message is null terminated after formatting */
+    const uint32_t actual_message_length = 0;
+
     /* Get the formatted message from the message buffer */
-    /* If logging to console */ {
-        /* Get the console prefix */
-        /* Log to console */
+    char* s_message_formatted = g_klog_state.b_messages_formatted
+        + (g_klog_state.message_element_consumer_idx * g_klog_state.message_formatted_max_size);
+
+    /* Get the console and file prefixes */
+    char* s_prefix_file    = g_klog_state.b_prefixes_file + (g_klog_state.message_element_consumer_idx * g_klog_state.prefix_file_size);
+    char* s_prefix_console = g_klog_state.b_prefixes_console
+        + (g_klog_state.message_element_consumer_idx * g_klog_state.prefix_console_size);
+    const KlogString packed_prefix_file    = { g_klog_state.prefix_file_size, s_prefix_file };
+    const KlogString packed_prefix_console = { g_klog_state.prefix_console_size, s_prefix_console };
+
+    uint32_t i_starting_character = 0;
+    while (i_starting_character <= actual_message_length) {
+        const char* const p_newline         = strchr(s_message_formatted + i_starting_character, '\n');
+        const uint32_t    submessage_length = p_newline
+            ? p_newline - (s_message_formatted + i_starting_character)
+            : actual_message_length;
+
+        const KlogString packed_message = { submessage_length, s_message_formatted + i_starting_character };
+        if (requested_level <= g_klog_config.console.max_level) {
+            klog_output_console(&packed_prefix_console, &packed_message);
+        }
+        if (g_klog_state.p_file && (requested_level <= g_klog_config.file.max_level)) {
+            klog_output_file(g_klog_state.p_file, &packed_prefix_file, &packed_message);
+        }
+
+        i_starting_character = i_starting_character + submessage_length + 1;
     }
-    /* If logging to file */ {
-        /* Get the file prefix */
-        /* Log to file */
+
+    /* Clear the buffer for the formatted message we just used */
+    memset(s_message_formatted, 0, g_klog_state.message_formatted_max_size);
+
+    /* Update the consumer's index into our ring buffer */
+    g_klog_state.message_element_consumer_idx = g_klog_state.message_element_consumer_idx + 1;
+    if (g_klog_state.message_element_consumer_idx >= g_klog_state.message_element_count) {
+        g_klog_state.message_element_consumer_idx = 0;
     }
-    /* Increment the consuming index */
+
+    g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count - 1;
+
     /* Release the mutex */
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_formatted_messages);
 }
 
 void* klog_thread_body(
@@ -166,7 +212,9 @@ void klog_initialize(
     );
     g_klog_state.prefix_time_size             = G_klog_time_string_length;
     g_klog_state.prefix_source_location_size  = g_klog_config.format.source_location_filename_max_length + 4 + 1; /* 4 digit line number, colon */
+    g_klog_state.message_unconsumed_count     = 0;
     g_klog_state.message_element_producer_idx = 0;
+    g_klog_state.message_element_consumer_idx = 0;
     if (p_klog_async_info) {
         g_klog_state.message_element_count = p_klog_async_info->message_queue_number_elements;
     } else {
@@ -283,7 +331,9 @@ void klog_deinitialize(
     g_klog_state.b_level_strings         = NULL;
     g_klog_state.b_level_strings_colored = NULL;
 
+    g_klog_state.message_unconsumed_count     = 0;
     g_klog_state.message_element_producer_idx = 0;
+    g_klog_state.message_element_consumer_idx = 0;
     g_klog_state.message_element_count        = 0;
 
     g_klog_state.prefix_file_size = 0;
@@ -436,6 +486,8 @@ void klog_log(
         return;
     }
 
+    klog_platform_mutex_lock(g_klog_state.p_mutex_formatted_messages);
+
     /* We are getting the time first, so it's closest to the actual point of invocation */
     char* s_prefix_time = g_klog_state.b_prefixes_time + (g_klog_state.message_element_producer_idx * g_klog_state.prefix_time_size);
     memset(s_prefix_time, '\0', g_klog_state.prefix_time_size);
@@ -503,6 +555,20 @@ void klog_log(
         &packed_source_location
     );
 
+    /* Update the producer's index into our ring buffer */
+    g_klog_state.message_element_producer_idx = g_klog_state.message_element_producer_idx + 1;
+    if (g_klog_state.message_element_producer_idx >= g_klog_state.message_element_count) {
+        g_klog_state.message_element_producer_idx = 0;
+    }
+
+    /* Let everyone know there is another message ready for consumption */
+    /* @todo Error out if we have gotten into a state not in accordance with our buffer full strategy? */
+    g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count + 1;
+
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_formatted_messages);
+
+    /* @todo if no backing threads, invoke consuming function directly, else return */
+
     /* Actually log the message */
     uint32_t i_starting_character = 0;
     while (i_starting_character <= actual_message_length) {
@@ -522,10 +588,10 @@ void klog_log(
         i_starting_character = i_starting_character + submessage_length + 1;
     }
 
-    /* Update the index into our ring buffer */
-    g_klog_state.message_element_producer_idx = g_klog_state.message_element_producer_idx + 1;
-    if (g_klog_state.message_element_producer_idx >= g_klog_state.message_element_count) {
-        g_klog_state.message_element_producer_idx = 0;
+    /* Update the consumer's index into our ring buffer */
+    g_klog_state.message_element_consumer_idx = g_klog_state.message_element_consumer_idx + 1;
+    if (g_klog_state.message_element_consumer_idx >= g_klog_state.message_element_count) {
+        g_klog_state.message_element_consumer_idx = 0;
     }
 
     /* Clear the buffer for the next time it is used - we also re-set the null terminator at the end of the actual message */

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "./klog_state.h"
+#include "./klog_async.h"
 #include "./klog_constants.h"
 #include "./klog_handle.h"
 #include "./klog_platform.h"
@@ -15,113 +16,6 @@
 #include "./klog_initialize.h"
 #include "./klog_output.h"
 #include "./klog_format.h"
-
-/* @todo Make these actual functions somewhere appropriate */
-/* ====================================================================================================================================== */
-
-bool klog_consume(
-    void
-) {
-    klog_platform_mutex_lock(g_klog_state.p_mutex_consumer);
-
-    klog_platform_semaphore_wait(g_klog_state.p_semaphore_messages_full);
-
-    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
-
-    if (g_klog_state.message_produced_total_count == g_klog_state.message_consumed_total_count) {
-        /* We have logged everything we should have - up to this point. Should we stop?? */
-        klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
-
-        if (!g_klog_state.is_initialized) {
-            /* We should stop */
-            klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
-            klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
-            klog_platform_mutex_unlock(g_klog_state.p_mutex_consumer);
-            return true;
-        }
-
-        /* Let's keep going */
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
-    }
-
-    /* Get the level from the global buffer of levels corresponding to messages */
-    const enum KlogLevel requested_level = g_klog_state.b_message_levels[g_klog_state.message_element_consumer_idx];
-
-    /* Get the formatted message from the message buffer */
-    char* s_message_formatted = g_klog_state.b_messages_formatted
-        + (g_klog_state.message_element_consumer_idx * g_klog_state.message_formatted_max_size);
-
-    /* @todo Do we need an additional buffer denoting lengths, for speed up so we don't have to use strlen? */
-    const uint32_t actual_message_length = strlen(s_message_formatted);
-
-    /* Get the console and file prefixes */
-    char* s_prefix_file    = g_klog_state.b_prefixes_file + (g_klog_state.message_element_consumer_idx * g_klog_state.prefix_file_size);
-    char* s_prefix_console = g_klog_state.b_prefixes_console
-        + (g_klog_state.message_element_consumer_idx * g_klog_state.prefix_console_size);
-    const KlogString packed_prefix_file    = { g_klog_state.prefix_file_size, s_prefix_file };
-    const KlogString packed_prefix_console = { g_klog_state.prefix_console_size, s_prefix_console };
-
-    uint32_t i_starting_character = 0;
-    while (i_starting_character <= actual_message_length) {
-        const char* const p_newline         = strchr(s_message_formatted + i_starting_character, '\n');
-        const uint32_t    submessage_length = p_newline
-            ? p_newline - (s_message_formatted + i_starting_character)
-            : actual_message_length;
-
-        const KlogString packed_message = { submessage_length, s_message_formatted + i_starting_character };
-        if (requested_level <= g_klog_config.console.max_level) {
-            klog_output_console(&packed_prefix_console, &packed_message);
-        }
-        if (g_klog_state.p_file && (requested_level <= g_klog_config.file.max_level)) {
-            klog_output_file(g_klog_state.p_file, &packed_prefix_file, &packed_message);
-        }
-
-        i_starting_character = i_starting_character + submessage_length + 1;
-    }
-
-    /* Clear the message buffer for the formatted message we just used */
-    /* @todo We shouldn't do this here - this should be done in the producer so we don't need to worry about staying sync-ed after outputting */
-    memset(s_message_formatted, 0, g_klog_state.message_formatted_max_size);
-
-    /* Update the consumer's index into our ring buffer */
-    g_klog_state.message_element_consumer_idx = g_klog_state.message_element_consumer_idx + 1;
-    if (g_klog_state.message_element_consumer_idx >= g_klog_state.message_element_count) {
-        g_klog_state.message_element_consumer_idx = 0;
-    }
-
-    if (g_klog_state.message_unconsumed_count < 1) {
-        kdprintf("klog_consume consumed too many messages\n");
-        exit(1);
-    }
-    g_klog_state.message_consumed_total_count++;
-    g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count - 1;
-
-    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
-
-    klog_platform_semaphore_signal(g_klog_state.p_semaphore_messages_empty);
-
-    klog_platform_mutex_unlock(g_klog_state.p_mutex_consumer);
-
-    return false;
-}
-
-void* klog_thread_body(
-    void* p
-) {
-    (void)p;
-
-    while (true) {
-        /* Acquire the formatted message mutex and invoke the "consnuming function" and stop if we should */
-        bool should_stop = klog_consume();
-        if (should_stop) {
-            break;
-        }
-    }
-
-    return NULL;
-}
-
-/* ====================================================================================================================================== */
 
 void klog_initialize(
     const uint32_t               max_number_loggers,
@@ -312,7 +206,7 @@ void klog_initialize(
     if (g_klog_config.async.number_backing_threads > 0) {
         g_klog_state.b_threads = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_thread_t) * g_klog_config.async.number_backing_threads);
         for (uint32_t idx_thread = 0; idx_thread < g_klog_config.async.number_backing_threads; ++idx_thread) {
-            klog_platform_thread_create(&g_klog_state.b_threads[idx_thread], klog_thread_body, NULL);
+            klog_platform_thread_create(&g_klog_state.b_threads[idx_thread], klog_async_thread_body, NULL);
         }
     }
 #endif
@@ -656,6 +550,6 @@ void klog_log(
     if (g_klog_config.async.number_backing_threads > 0) {
         return;
     }
-    klog_consume();
+    klog_async_consume();
 #endif
 }

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -295,22 +295,22 @@ void klog_initialize(
     g_klog_state.filename_string = klog_format_filename(p_klog_file_info, g_klog_config.alloc.alloc_cb, g_klog_config.alloc.free_cb);
     g_klog_state.p_file          = klog_initialize_file(g_klog_state.filename_string);
 
-    g_klog_state.p_mutex_deinitialize = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
-    g_klog_state.p_mutex_shared       = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
-    g_klog_state.p_mutex_producer     = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
-    g_klog_state.p_mutex_consumer     = g_klog_config.alloc.alloc_cb(sizeof(kpl_mutex_t));
+    g_klog_state.p_mutex_deinitialize = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_shared       = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_producer     = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_consumer     = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
     klog_platform_mutex_initialize(g_klog_state.p_mutex_deinitialize);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_shared);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_producer);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_consumer);
 
-    g_klog_state.p_semaphore_messages_empty = g_klog_config.alloc.alloc_cb(sizeof(kpl_semaphore_t));
-    g_klog_state.p_semaphore_messages_full  = g_klog_config.alloc.alloc_cb(sizeof(kpl_semaphore_t));
+    g_klog_state.p_semaphore_messages_empty = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_semaphore_t));
+    g_klog_state.p_semaphore_messages_full  = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_semaphore_t));
     klog_platform_semaphore_initialize(g_klog_state.p_semaphore_messages_empty, g_klog_state.message_element_count);
     klog_platform_semaphore_initialize(g_klog_state.p_semaphore_messages_full,  0);
 
     if (g_klog_config.async.number_backing_threads > 0) {
-        g_klog_state.b_threads = g_klog_config.alloc.alloc_cb(sizeof(kpl_thread_t) * g_klog_config.async.number_backing_threads);
+        g_klog_state.b_threads = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_thread_t) * g_klog_config.async.number_backing_threads);
         for (uint32_t idx_thread = 0; idx_thread < g_klog_config.async.number_backing_threads; ++idx_thread) {
             klog_platform_thread_create(&g_klog_state.b_threads[idx_thread], klog_thread_body, NULL);
         }

--- a/src/klog/klog_async.c
+++ b/src/klog/klog_async.c
@@ -27,7 +27,6 @@ void* klog_async_thread_body(
     (void)p;
 
     while (true) {
-        /* Acquire the formatted message mutex and invoke the "consnuming function" and stop if we should */
         bool should_stop = klog_async_consume();
         if (should_stop) {
             break;

--- a/src/klog/klog_async.c
+++ b/src/klog/klog_async.c
@@ -1,0 +1,124 @@
+#include "./klog_async.h"
+
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "klog/klog.h"
+
+/**
+ * @brief This is the ONLY non klog.c source file which is allowed to directly include and
+ *      use the klog_state.h header file. This is because we use so much of the state in these
+ *      async functions, that it would be incredibly cumbersome to pass everything in via
+ *      parameters. Maybe we ought to revisit this decision in the future.
+ */
+#include "./klog_state.h"
+#include "./klog_debug_util.h"
+#include "./klog_format.h"
+#include "./klog_output.h"
+#include "./klog_platform.h"
+
+void* klog_async_thread_body(
+    void* p
+) {
+    (void)p;
+
+    while (true) {
+        /* Acquire the formatted message mutex and invoke the "consnuming function" and stop if we should */
+        bool should_stop = klog_async_consume();
+        if (should_stop) {
+            break;
+        }
+    }
+
+    return NULL;
+}
+
+bool klog_async_consume(
+    void
+) {
+    klog_platform_mutex_lock(g_klog_state.p_mutex_consumer);
+
+    klog_platform_semaphore_wait(g_klog_state.p_semaphore_messages_full);
+
+    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
+
+    if (g_klog_state.message_produced_total_count == g_klog_state.message_consumed_total_count) {
+        /* We have logged everything we should have - up to this point. Should we stop?? */
+        klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
+
+        if (!g_klog_state.is_initialized) {
+            /* We should stop */
+            klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
+            klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
+            klog_platform_mutex_unlock(g_klog_state.p_mutex_consumer);
+            return true;
+        }
+
+        /* Let's keep going */
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
+    }
+
+    /* Get the level from the global buffer of levels corresponding to messages */
+    const enum KlogLevel requested_level = g_klog_state.b_message_levels[g_klog_state.message_element_consumer_idx];
+
+    /* Get the formatted message from the message buffer */
+    char* s_message_formatted = g_klog_state.b_messages_formatted
+        + (g_klog_state.message_element_consumer_idx * g_klog_state.message_formatted_max_size);
+
+    /* @todo Do we need an additional buffer denoting lengths, for speed up so we don't have to use strlen? */
+    const uint32_t actual_message_length = strlen(s_message_formatted);
+
+    /* Get the console and file prefixes */
+    char* s_prefix_file    = g_klog_state.b_prefixes_file + (g_klog_state.message_element_consumer_idx * g_klog_state.prefix_file_size);
+    char* s_prefix_console = g_klog_state.b_prefixes_console
+        + (g_klog_state.message_element_consumer_idx * g_klog_state.prefix_console_size);
+    const KlogString packed_prefix_file    = { g_klog_state.prefix_file_size, s_prefix_file };
+    const KlogString packed_prefix_console = { g_klog_state.prefix_console_size, s_prefix_console };
+
+    uint32_t i_starting_character = 0;
+    while (i_starting_character <= actual_message_length) {
+        const char* const p_newline         = strchr(s_message_formatted + i_starting_character, '\n');
+        const uint32_t    submessage_length = p_newline
+            ? p_newline - (s_message_formatted + i_starting_character)
+            : actual_message_length;
+
+        const KlogString packed_message = { submessage_length, s_message_formatted + i_starting_character };
+        if (requested_level <= g_klog_config.console.max_level) {
+            klog_output_console(&packed_prefix_console, &packed_message);
+        }
+        if (g_klog_state.p_file && (requested_level <= g_klog_config.file.max_level)) {
+            klog_output_file(g_klog_state.p_file, &packed_prefix_file, &packed_message);
+        }
+
+        i_starting_character = i_starting_character + submessage_length + 1;
+    }
+
+    /* Clear the message buffer for the formatted message we just used */
+    /* @todo We shouldn't do this here - this should be done in the producer so we don't need to worry about staying sync-ed after outputting */
+    memset(s_message_formatted, 0, g_klog_state.message_formatted_max_size);
+
+    /* Update the consumer's index into our ring buffer */
+    g_klog_state.message_element_consumer_idx = g_klog_state.message_element_consumer_idx + 1;
+    if (g_klog_state.message_element_consumer_idx >= g_klog_state.message_element_count) {
+        g_klog_state.message_element_consumer_idx = 0;
+    }
+
+    if (g_klog_state.message_unconsumed_count < 1) {
+        kdprintf("klog_async_consume consumed too many messages\n");
+        exit(1);
+    }
+    g_klog_state.message_consumed_total_count++;
+    g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count - 1;
+
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
+
+    klog_platform_semaphore_signal(g_klog_state.p_semaphore_messages_empty);
+
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_consumer);
+
+    return false;
+}

--- a/src/klog/klog_async.h
+++ b/src/klog/klog_async.h
@@ -1,0 +1,14 @@
+#ifndef KLOG_ASYNC_INCLUDED
+#define KLOG_ASYNC_INCLUDED
+
+#include <stdbool.h>
+
+void* klog_async_thread_body(
+    void* p
+);
+
+bool klog_async_consume(
+    void
+);
+
+#endif /* KLOG_ASYNC_INCLUDED */

--- a/src/klog/klog_format.c
+++ b/src/klog/klog_format.c
@@ -28,7 +28,7 @@ uint32_t klog_format_prefix_length_get(
     if (use_timestamp) {
         total += G_klog_time_string_length + 1; /* 19 digit timestamp + space */
     }
-    total += logger_name_max_length + 2 + 1; /* logger name + brackets + space */
+    total += logger_name_max_length + 2 + 1;     /* logger name + brackets + space */
     total += G_klog_level_string_length + 2 + 1; /* level + brackets + space */
     if (use_color) {
         total += 9;
@@ -118,7 +118,7 @@ KlogString klog_format_message_prefix(
     /**
      * @brief So in total we have:
      *      8[thread id and space] +
-     *      (p_time.length)[timestamp and space] +
+     *      (p_time.length+1)[timestamp and space] +
      *      (p_name.length+3)[logger name, brackets, space] +
      *      (p_level+3)[level name, brackets, space] +
      *      (p_source_location.length+3)[source location, brackets, space]

--- a/src/klog/klog_format.c
+++ b/src/klog/klog_format.c
@@ -13,6 +13,50 @@
 #include "./klog_debug_util.h"
 #include "./klog_platform.h"
 
+char* klog_format_filename(
+    const KlogFileInfo* const p_klog_file_info,
+    void* (* const            alloc_cb)(
+        size_t size
+    ),
+    void (*                   free_cb)(
+        void*
+    )
+) {
+    if (p_klog_file_info == NULL) {
+        kdprintf("Not initializing output file\n");
+        return NULL;
+    }
+
+    const timepoint_t timepoint = klog_platform_get_current_timepoint();
+
+    /* This is a null terminated string with all whitespace removed */
+    const char* const s_sanitized_prefix = klog_format_file_name_prefix(p_klog_file_info->s_filename_prefix, alloc_cb);
+
+    /* Filename's are formatted like: <prefix>_YYYYMMDD_HHMMSS_SSSS.log */
+    /* Extra chars                  : 00+     123456789                 */
+    /*                                10+              0123456789       */
+    /*                                20+                        012345 */
+    const uint32_t prefix_length        = strlen(s_sanitized_prefix) + 1; /* +1 for null terminator */
+    const uint32_t full_filename_length = prefix_length + 25 + 1;         /* +1 for null terminator */
+    char* const    full_filename        = alloc_cb(full_filename_length);
+    sprintf(
+        full_filename,
+        "%s_%.4d%.2d%.2d_%.2d%.2d%.2d_%.4d.log",
+        s_sanitized_prefix, /* %s expects a null terminated string */
+        timepoint.year,
+        timepoint.month,
+        timepoint.day_month,
+        timepoint.hour,
+        timepoint.minute,
+        timepoint.second,
+        timepoint.microsecond / 1000
+    );
+
+    free_cb((char*)s_sanitized_prefix);
+
+    return full_filename;
+}
+
 uint32_t klog_format_prefix_length_get(
     const bool     use_thread_id,
     const bool     use_timestamp,

--- a/src/klog/klog_format.c
+++ b/src/klog/klog_format.c
@@ -129,7 +129,7 @@ KlogString klog_format_message_prefix(
     /* @todo should we use our prefix_length_get function here? */
     /* @todo should we memset to 0 at the front here instead of the end of klog_log? */
 
-    uint32_t size_total = 0;
+    uint32_t size_total = 1;
     if (p_thread_id) {
         size_total = size_total + 8;
     }
@@ -144,10 +144,6 @@ KlogString klog_format_message_prefix(
     }
     if (p_source_location && p_source_location->length) {
         size_total = size_total + p_source_location->length + 3;
-    }
-
-    if (size_total == 0) {
-        return (KlogString) { 0, s_prefix };
     }
 
     if (!s_prefix) {
@@ -178,7 +174,7 @@ KlogString klog_format_message_prefix(
     }
 
     /* Set the final byte to the null terminator */
-    s_prefix[size_total] = '\0';
+    s_prefix[size_total - 1] = '\0';
 
     return (KlogString) { size_total, s_prefix };
 }

--- a/src/klog/klog_format.c
+++ b/src/klog/klog_format.c
@@ -37,6 +37,8 @@ uint32_t klog_format_prefix_length_get(
         total += source_location_filename_max_length + 2 + 1 + 4 + 1; /* filename + brackets + colon + line + space */
     }
 
+    total += 1; /* Null terminator */
+
     return total;
 }
 

--- a/src/klog/klog_format.h
+++ b/src/klog/klog_format.h
@@ -13,6 +13,10 @@ typedef struct {
     const char* const s;
 } KlogString;
 
+/**
+ * @brief This removes the whitespace from the provided prefix, and returns a newly
+ * allocated null terminated string containing the sanitized prefix and a timestamp.
+ */
 char* klog_format_filename(
     const KlogFileInfo* const p_klog_file_info,
     void* (* const            alloc_cb)(

--- a/src/klog/klog_format.h
+++ b/src/klog/klog_format.h
@@ -6,10 +6,22 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "klog/klog.h"
+
 typedef struct {
     uint32_t          length;
     const char* const s;
 } KlogString;
+
+char* klog_format_filename(
+    const KlogFileInfo* const p_klog_file_info,
+    void* (* const            alloc_cb)(
+        size_t size
+    ),
+    void (*                   free_cb)(
+        void*
+    )
+);
 
 uint32_t klog_format_prefix_length_get(
     const bool     use_thread_id,

--- a/src/klog/klog_initialize.c
+++ b/src/klog/klog_initialize.c
@@ -200,16 +200,16 @@ char* klog_initialize_colored_level_strings_buffer(
 }
 
 FILE* klog_initialize_file(
-    const char* const filename_string
+    const char* const s_filename
 ) {
-    if (filename_string == NULL) {
+    if (s_filename == NULL) {
         kdprintf("Not initializing output file\n");
         return NULL;
     }
 
-    FILE* const p_file = fopen(filename_string, "w");
+    FILE* const p_file = fopen(s_filename, "w");
     if (!p_file) {
-        kdprintf("Failed to create log file at %s\n", filename_string);
+        kdprintf("Failed to create log file at %s\n", s_filename);
         exit(KLOG_EXIT_CODE);
     }
     kdprintf("Created output file pointer at %p\n", (void*)p_file);

--- a/src/klog/klog_initialize.c
+++ b/src/klog/klog_initialize.c
@@ -71,14 +71,21 @@ bool klog_initialize_are_parameters_valid(
     }
 
     if (p_klog_async_info) {
-        /* @todo kjk 2026/01/21 Validate async info */
         /* @todo kjk 2026/02/09 Add test to ut-klog_initialize_parmaeters_are_valid.c */
+        if (p_klog_async_info->message_queue_number_elements == 0) {
+            kdprintf("Trying to initialize klog with an async message queue of size 0\n");
+            return false;
+        }
+        if (p_klog_async_info->number_backing_threads == 0) {
+            kdprintf("Trying to initialize klog with async information, but using 0 backing threads\n");
+            return false;
+        }
     }
 
     if (p_klog_file_info) {
         /* @todo kjk 2026/01/21 Validate file info */
         /* @todo kjk 2026/02/09 Add test to ut-klog_initialize_parmaeters_are_valid.c */
-        /* Make sure filename prefix is valid */
+        /* @todo kjk 2026/07/28 Make sure filename prefix is valid */
     }
 
     if (p_klog_alloc_info) {

--- a/src/klog/klog_initialize.c
+++ b/src/klog/klog_initialize.c
@@ -193,49 +193,19 @@ char* klog_initialize_colored_level_strings_buffer(
 }
 
 FILE* klog_initialize_file(
-    const KlogFileInfo* const p_klog_file_info,
-    void* (* const            alloc_cb)(
-        size_t size
-    )
+    const char* const filename_string
 ) {
-    if (p_klog_file_info == NULL) {
+    if (filename_string == NULL) {
         kdprintf("Not initializing output file\n");
         return NULL;
     }
 
-    const timepoint_t timepoint = klog_platform_get_current_timepoint();
-
-    /* This is a null terminated string with all whitespace removed */
-    const char* const s_sanitized_prefix = klog_format_file_name_prefix(p_klog_file_info->s_filename_prefix, alloc_cb);
-
-    /* Filename's are formatted like: <prefix>_YYYYMMDD_HHMMSS_SSSS.log */
-    /* Extra chars                  : 00+     123456789                 */
-    /*                                10+              0123456789       */
-    /*                                20+                        012345 */
-    const uint32_t prefix_length        = strlen(s_sanitized_prefix) + 1; /* +1 for null terminator */
-    const uint32_t full_filename_length = prefix_length + 25 + 1; /* +1 for null terminator */
-    char* const    full_filename        = alloc_cb(full_filename_length);
-    sprintf(
-        full_filename,
-        "%s_%.4d%.2d%.2d_%.2d%.2d%.2d_%.4d.log",
-        s_sanitized_prefix, /* %s expects a null terminated string */
-        timepoint.year,
-        timepoint.month,
-        timepoint.day_month,
-        timepoint.hour,
-        timepoint.minute,
-        timepoint.second,
-        timepoint.microsecond / 1000
-    );
-
-    FILE* const p_file = fopen(full_filename, "w");
+    FILE* const p_file = fopen(filename_string, "w");
     if (!p_file) {
-        kdprintf("Failed to create log file at %s\n", full_filename);
+        kdprintf("Failed to create log file at %s\n", filename_string);
         exit(KLOG_EXIT_CODE);
     }
     kdprintf("Created output file pointer at %p\n", (void*)p_file);
 
-    free((char*)s_sanitized_prefix);
-    free(full_filename);
     return p_file;
 }

--- a/src/klog/klog_initialize.h
+++ b/src/klog/klog_initialize.h
@@ -54,10 +54,7 @@ char* klog_initialize_colored_level_strings_buffer(
 );
 
 FILE* klog_initialize_file(
-    const KlogFileInfo* p_klog_file_info,
-    void* (* const      alloc_cb)(
-        size_t size
-    )
+    const char* const filename_string
 );
 
 #endif /* KLOG_INITIALIZE_INCLUDED */

--- a/src/klog/klog_initialize.h
+++ b/src/klog/klog_initialize.h
@@ -53,8 +53,11 @@ char* klog_initialize_colored_level_strings_buffer(
     )
 );
 
+/**
+ * @brief the input filename must be null terminated.
+ */
 FILE* klog_initialize_file(
-    const char* const filename_string
+    const char* const s_filename
 );
 
 #endif /* KLOG_INITIALIZE_INCLUDED */

--- a/src/klog/klog_platform.c
+++ b/src/klog/klog_platform.c
@@ -17,7 +17,7 @@ procid_t klog_platform_get_current_thread_id(
 void klog_platform_mutex_initialize(
     klog_platform_mutex_t* p_mutex
 ) {
-    int result = pthread_mutex_init(p_mutex, NULL); /* "pthread_mutex_init() always returns 0" - from the man page ????? */
+    int32_t result = pthread_mutex_init(p_mutex, NULL); /* "pthread_mutex_init() always returns 0" - from the man page ????? */
     if (result == EBUSY) {
         kdprintf("pthread_mutex_init returned %d: Mutex is already initialized\n", result);
         exit(KLOG_EXIT_CODE);
@@ -46,7 +46,7 @@ void klog_platform_mutex_initialize(
 void klog_platform_mutex_deinitialize(
     klog_platform_mutex_t* p_mutex
 ) {
-    int result = pthread_mutex_destroy(p_mutex);
+    int32_t result = pthread_mutex_destroy(p_mutex);
     if (result == EBUSY) {
         kdprintf("pthread_mutex_destroy returned %d: Attempt to destroy mutex while it is locked\n", result);
         exit(KLOG_EXIT_CODE);
@@ -60,7 +60,7 @@ void klog_platform_mutex_deinitialize(
 void klog_platform_mutex_lock(
     klog_platform_mutex_t* p_mutex
 ) {
-    int result = pthread_mutex_lock(p_mutex);
+    int32_t result = pthread_mutex_lock(p_mutex);
     if (result == EINVAL) {
         kdprintf("pthread_mutex_lock returned %d: Mutex is not initialized\n", result);
         exit(KLOG_EXIT_CODE);
@@ -86,7 +86,7 @@ void klog_platform_mutex_lock(
 void klog_platform_mutex_unlock(
     klog_platform_mutex_t* p_mutex
 ) {
-    int result = pthread_mutex_unlock(p_mutex);
+    int32_t result = pthread_mutex_unlock(p_mutex);
     if (result == EINVAL) {
         kdprintf("pthread_mutex_unlock returned %d: Mutex is not initialized\n", result);
         exit(KLOG_EXIT_CODE);
@@ -113,7 +113,7 @@ void klog_platform_semaphore_initialize(
     klog_platform_semaphore_t* p_semaphore,
     uint32_t                   count
 ) {
-    int retval = sem_init(p_semaphore, 0, count);
+    int32_t retval = sem_init(p_semaphore, 0, count);
     if (retval != 0) {
         kdprintf("Error in klog_platform_semaphore_initialize: sem_init returned %d - errno: %s\n", retval, strerror(errno));
         exit(KLOG_EXIT_CODE);
@@ -123,7 +123,7 @@ void klog_platform_semaphore_initialize(
 void klog_platform_semaphore_deinitialize(
     klog_platform_semaphore_t* p_semaphore
 ) {
-    const int retval = sem_destroy(p_semaphore);
+    const int32_t retval = sem_destroy(p_semaphore);
     if (retval != 0) {
         kdprintf("Error in klog_platform_semaphore_deinitialize: sem_destroy returned %d - errno: %s\n", retval, strerror(errno));
         exit(KLOG_EXIT_CODE);
@@ -133,7 +133,7 @@ void klog_platform_semaphore_deinitialize(
 void klog_platform_semaphore_wait(
     klog_platform_semaphore_t* p_semaphore
 ) {
-    const int retval = sem_wait(p_semaphore);
+    const int32_t retval = sem_wait(p_semaphore);
     if (retval != 0) {
         kdprintf("Error in klog_platform_semaphore_wait: sem_wait returned %d - errno: %s\n", retval, strerror(errno));
         exit(KLOG_EXIT_CODE);
@@ -143,18 +143,18 @@ void klog_platform_semaphore_wait(
 void klog_platform_semaphore_signal(
     klog_platform_semaphore_t* p_semaphore
 ) {
-    const int retval = sem_post(p_semaphore);
+    const int32_t retval = sem_post(p_semaphore);
     if (retval != 0) {
         kdprintf("Error in klog_platform_semaphore_signal: sem_post returned %d - errno: %s\n", retval, strerror(errno));
         exit(KLOG_EXIT_CODE);
     }
 }
 
-int klog_platform_semaphore_value_get(
+int32_t klog_platform_semaphore_value_get(
     klog_platform_semaphore_t* p_semaphore
 ) {
-    int       result = 0;
-    const int retval = sem_getvalue(p_semaphore, &result);
+    int32_t       result = 0;
+    const int32_t retval = sem_getvalue(p_semaphore, &result);
     if (retval != 0) {
         kdprintf("Error in klog_platform_semaphore_value_get: sem_getvalue returned %d - errno: %s\n", retval, strerror(errno));
         exit(KLOG_EXIT_CODE);
@@ -169,7 +169,7 @@ void klog_platform_thread_create(
     ),
     void*                   p_arg
 ) {
-    int result = pthread_create(p_thread, NULL, thread_body, p_arg);
+    int32_t result = pthread_create(p_thread, NULL, thread_body, p_arg);
     if (result == EAGAIN) {
         kdprintf("pthread_create returned %d: Insufficient resources to create another thread\n", result);
         exit(KLOG_EXIT_CODE);
@@ -191,7 +191,7 @@ void klog_platform_thread_join(
     klog_platform_thread_t* p_thread,
     void**                  p_ret
 ) {
-    int result = pthread_join(*p_thread, p_ret);
+    int32_t result = pthread_join(*p_thread, p_ret);
     if (result == EDEADLK) {
         kdprintf("pthread_join returned %d: A deadlock was detected, or we are trying to join the calling thread (ourself)\n", result);
         exit(KLOG_EXIT_CODE);

--- a/src/klog/klog_platform.c
+++ b/src/klog/klog_platform.c
@@ -15,7 +15,7 @@ procid_t klog_platform_get_current_thread_id(
 }
 
 void klog_platform_mutex_initialize(
-    kpl_mutex_t* p_mutex
+    klog_platform_mutex_t* p_mutex
 ) {
     int result = pthread_mutex_init(p_mutex, NULL); /* "pthread_mutex_init() always returns 0" - from the man page ????? */
     if (result == EBUSY) {
@@ -44,7 +44,7 @@ void klog_platform_mutex_initialize(
 }
 
 void klog_platform_mutex_deinitialize(
-    kpl_mutex_t* p_mutex
+    klog_platform_mutex_t* p_mutex
 ) {
     int result = pthread_mutex_destroy(p_mutex);
     if (result == EBUSY) {
@@ -58,7 +58,7 @@ void klog_platform_mutex_deinitialize(
 }
 
 void klog_platform_mutex_lock(
-    kpl_mutex_t* p_mutex
+    klog_platform_mutex_t* p_mutex
 ) {
     int result = pthread_mutex_lock(p_mutex);
     if (result == EINVAL) {
@@ -84,7 +84,7 @@ void klog_platform_mutex_lock(
 }
 
 void klog_platform_mutex_unlock(
-    kpl_mutex_t* p_mutex
+    klog_platform_mutex_t* p_mutex
 ) {
     int result = pthread_mutex_unlock(p_mutex);
     if (result == EINVAL) {
@@ -110,8 +110,8 @@ void klog_platform_mutex_unlock(
 }
 
 void klog_platform_semaphore_initialize(
-    kpl_semaphore_t* p_semaphore,
-    uint32_t         count
+    klog_platform_semaphore_t* p_semaphore,
+    uint32_t                   count
 ) {
     int retval = sem_init(p_semaphore, 0, count);
     if (retval != 0) {
@@ -121,7 +121,7 @@ void klog_platform_semaphore_initialize(
 }
 
 void klog_platform_semaphore_deinitialize(
-    kpl_semaphore_t* p_semaphore
+    klog_platform_semaphore_t* p_semaphore
 ) {
     const int retval = sem_destroy(p_semaphore);
     if (retval != 0) {
@@ -131,7 +131,7 @@ void klog_platform_semaphore_deinitialize(
 }
 
 void klog_platform_semaphore_wait(
-    kpl_semaphore_t* p_semaphore
+    klog_platform_semaphore_t* p_semaphore
 ) {
     const int retval = sem_wait(p_semaphore);
     if (retval != 0) {
@@ -141,7 +141,7 @@ void klog_platform_semaphore_wait(
 }
 
 void klog_platform_semaphore_signal(
-    kpl_semaphore_t* p_semaphore
+    klog_platform_semaphore_t* p_semaphore
 ) {
     const int retval = sem_post(p_semaphore);
     if (retval != 0) {
@@ -151,7 +151,7 @@ void klog_platform_semaphore_signal(
 }
 
 int klog_platform_semaphore_value_get(
-    kpl_semaphore_t* p_semaphore
+    klog_platform_semaphore_t* p_semaphore
 ) {
     int       result = 0;
     const int retval = sem_getvalue(p_semaphore, &result);
@@ -163,11 +163,11 @@ int klog_platform_semaphore_value_get(
 }
 
 void klog_platform_thread_create(
-    kpl_thread_t* p_thread,
-    void* (*      thread_body)(
+    klog_platform_thread_t* p_thread,
+    void* (*                thread_body)(
         void*
     ),
-    void*         p_arg
+    void*                   p_arg
 ) {
     int result = pthread_create(p_thread, NULL, thread_body, p_arg);
     if (result == EAGAIN) {
@@ -188,8 +188,8 @@ void klog_platform_thread_create(
 }
 
 void klog_platform_thread_join(
-    kpl_thread_t* p_thread,
-    void**        p_ret
+    klog_platform_thread_t* p_thread,
+    void**                  p_ret
 ) {
     int result = pthread_join(*p_thread, p_ret);
     if (result == EDEADLK) {

--- a/src/klog/klog_platform.c
+++ b/src/klog/klog_platform.c
@@ -12,6 +12,47 @@ procid_t klog_platform_get_current_thread_id(
     return syscall(SYS_gettid);
 }
 
+void klog_platform_mutex_initialize(
+    kpl_mutex_t* p_mutex
+) {
+    pthread_mutex_init(p_mutex, NULL);
+}
+
+void klog_platform_mutex_deinitialize(
+    kpl_mutex_t* p_mutex
+) {
+    pthread_mutex_destroy(p_mutex);
+}
+
+void klog_platform_mutex_lock(
+    kpl_mutex_t* p_mutex
+) {
+    pthread_mutex_lock(p_mutex);
+}
+
+void klog_platform_mutex_unlock(
+    kpl_mutex_t* p_mutex
+) {
+    pthread_mutex_unlock(p_mutex);
+}
+
+void klog_platform_thread_create(
+    kpl_thread_t* p_thread,
+    void* (*      thread_body)(
+        void*
+    ),
+    void*         p_arg
+) {
+    pthread_create(p_thread, NULL, thread_body, p_arg);
+}
+
+void klog_platform_thread_join(
+    kpl_thread_t* p_thread,
+    void**        p_ret
+) {
+    pthread_join(*p_thread, p_ret);
+}
+
 const char* klog_platform_get_basename(
     const char* const s_filepath
 ) {

--- a/src/klog/klog_platform.c
+++ b/src/klog/klog_platform.c
@@ -53,6 +53,15 @@ void klog_platform_thread_join(
     pthread_join(*p_thread, p_ret);
 }
 
+void sleep_usec(
+    const uint32_t usec
+) {
+    struct timespec ts;
+    ts.tv_sec  = usec / 1000000;          /* Whole seconds */
+    ts.tv_nsec = (usec % 1000000) * 1000; /* Remaining nanoseconds */
+    nanosleep(&ts, NULL);
+}
+
 const char* klog_platform_get_basename(
     const char* const s_filepath
 ) {

--- a/src/klog/klog_platform.c
+++ b/src/klog/klog_platform.c
@@ -1,6 +1,8 @@
 #include "./klog_platform.h"
 
+#include <errno.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "klog/klog.h"
 
@@ -34,6 +36,59 @@ void klog_platform_mutex_unlock(
     kpl_mutex_t* p_mutex
 ) {
     pthread_mutex_unlock(p_mutex);
+}
+
+void klog_platform_semaphore_initialize(
+    kpl_semaphore_t* p_semaphore,
+    uint32_t         count
+) {
+    int retval = sem_init(p_semaphore, 0, count);
+    if (retval != 0) {
+        kdprintf("Error in klog_platform_semaphore_initialize: sem_init returned %d - errno: %s\n", retval, strerror(errno));
+        exit(KLOG_EXIT_CODE);
+    }
+}
+
+void klog_platform_semaphore_deinitialize(
+    kpl_semaphore_t* p_semaphore
+) {
+    const int retval = sem_destroy(p_semaphore);
+    if (retval != 0) {
+        kdprintf("Error in klog_platform_semaphore_deinitialize: sem_destroy returned %d - errno: %s\n", retval, strerror(errno));
+        exit(KLOG_EXIT_CODE);
+    }
+}
+
+void klog_platform_semaphore_wait(
+    kpl_semaphore_t* p_semaphore
+) {
+    const int retval = sem_wait(p_semaphore);
+    if (retval != 0) {
+        kdprintf("Error in klog_platform_semaphore_wait: sem_wait returned %d - errno: %s\n", retval, strerror(errno));
+        exit(KLOG_EXIT_CODE);
+    }
+}
+
+void klog_platform_semaphore_signal(
+    kpl_semaphore_t* p_semaphore
+) {
+    const int retval = sem_post(p_semaphore);
+    if (retval != 0) {
+        kdprintf("Error in klog_platform_semaphore_signal: sem_post returned %d - errno: %s\n", retval, strerror(errno));
+        exit(KLOG_EXIT_CODE);
+    }
+}
+
+int klog_platform_semaphore_value_get(
+    kpl_semaphore_t* p_semaphore
+) {
+    int       result = 0;
+    const int retval = sem_getvalue(p_semaphore, &result);
+    if (retval != 0) {
+        kdprintf("Error in klog_platform_semaphore_value_get: sem_getvalue returned %d - errno: %s\n", retval, strerror(errno));
+        exit(KLOG_EXIT_CODE);
+    }
+    return result;
 }
 
 void klog_platform_thread_create(

--- a/src/klog/klog_platform.c
+++ b/src/klog/klog_platform.c
@@ -17,25 +17,96 @@ procid_t klog_platform_get_current_thread_id(
 void klog_platform_mutex_initialize(
     kpl_mutex_t* p_mutex
 ) {
-    pthread_mutex_init(p_mutex, NULL);
+    int result = pthread_mutex_init(p_mutex, NULL); /* "pthread_mutex_init() always returns 0" - from the man page ????? */
+    if (result == EBUSY) {
+        kdprintf("pthread_mutex_init returned %d: Mutex is already initialized\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == EAGAIN) {
+        kdprintf("pthread_mutex_init returned %d: Insufficient resources to initialize another mutex\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == ENOMEM) {
+        kdprintf("pthread_mutex_init returned %d: Insufficient memory exists to initialize another mutex\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == EINVAL) {
+        kdprintf("pthread_mutex_init returned %d: Attributes are invalid\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == EPERM) {
+        kdprintf(
+            "pthread_mutex_init returned %d: Caller doesn't have permission for the operation\n",
+            result
+        );
+        exit(KLOG_EXIT_CODE);
+    }
 }
 
 void klog_platform_mutex_deinitialize(
     kpl_mutex_t* p_mutex
 ) {
-    pthread_mutex_destroy(p_mutex);
+    int result = pthread_mutex_destroy(p_mutex);
+    if (result == EBUSY) {
+        kdprintf("pthread_mutex_destroy returned %d: Attempt to destroy mutex while it is locked\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == EINVAL) {
+        kdprintf("pthread_mutex_destroy returned %d: The mutex specified is invalid\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
 }
 
 void klog_platform_mutex_lock(
     kpl_mutex_t* p_mutex
 ) {
-    pthread_mutex_lock(p_mutex);
+    int result = pthread_mutex_lock(p_mutex);
+    if (result == EINVAL) {
+        kdprintf("pthread_mutex_lock returned %d: Mutex is not initialized\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == EBUSY) {
+        kdprintf("pthread_mutex_lock returned %d: Mutex couldn't be acquired because it was already locked\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == EAGAIN) {
+        kdprintf("pthread_mutex_lock returned %d: Maximum number of recursive locks has been exceeded\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == EDEADLK) {
+        kdprintf("pthread_mutex_lock returned %d: Deadlock condition was detected, or current thread already owns mutex\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == EPERM) {
+        kdprintf("pthread_mutex_lock returned %d: Current thread does not own the mutex\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
 }
 
 void klog_platform_mutex_unlock(
     kpl_mutex_t* p_mutex
 ) {
-    pthread_mutex_unlock(p_mutex);
+    int result = pthread_mutex_unlock(p_mutex);
+    if (result == EINVAL) {
+        kdprintf("pthread_mutex_unlock returned %d: Mutex is not initialized\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == EBUSY) {
+        kdprintf("pthread_mutex_unlock returned %d: Mutex is already locked\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == EAGAIN) {
+        kdprintf("pthread_mutex_unlock returned %d: Maximum number of recursive locks has been exceeded\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == EDEADLK) {
+        kdprintf("pthread_mutex_unlock returned %d: Deadlock condition was detected, or current thread already owns mutex\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == EPERM) {
+        kdprintf("pthread_mutex_unlock returned %d: Current thread does not own the mutex\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
 }
 
 void klog_platform_semaphore_initialize(
@@ -98,14 +169,41 @@ void klog_platform_thread_create(
     ),
     void*         p_arg
 ) {
-    pthread_create(p_thread, NULL, thread_body, p_arg);
+    int result = pthread_create(p_thread, NULL, thread_body, p_arg);
+    if (result == EAGAIN) {
+        kdprintf("pthread_create returned %d: Insufficient resources to create another thread\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == EINVAL) {
+        kdprintf("pthread_create returned %d: Invalid thread attribute settings\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == EPERM) {
+        kdprintf(
+            "pthread_create returned %d: No permission to set the scheduling policy and parameters specified in thread attribute settings\n",
+            result
+        );
+        exit(KLOG_EXIT_CODE);
+    }
 }
 
 void klog_platform_thread_join(
     kpl_thread_t* p_thread,
     void**        p_ret
 ) {
-    pthread_join(*p_thread, p_ret);
+    int result = pthread_join(*p_thread, p_ret);
+    if (result == EDEADLK) {
+        kdprintf("pthread_join returned %d: A deadlock was detected, or we are trying to join the calling thread (ourself)\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == EINVAL) {
+        kdprintf("pthread_join returned %d: The thread we are trying to join is not a joinable thread\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
+    if (result == ESRCH) {
+        kdprintf("pthread_join returned %d: No thread with the specified ID could be found\n", result);
+        exit(KLOG_EXIT_CODE);
+    }
 }
 
 void klog_platform_sleep_usec(

--- a/src/klog/klog_platform.c
+++ b/src/klog/klog_platform.c
@@ -108,7 +108,7 @@ void klog_platform_thread_join(
     pthread_join(*p_thread, p_ret);
 }
 
-void sleep_usec(
+void klog_platform_sleep_usec(
     const uint32_t usec
 ) {
     struct timespec ts;

--- a/src/klog/klog_platform.h
+++ b/src/klog/klog_platform.h
@@ -36,8 +36,10 @@ procid_t klog_platform_get_current_thread_id(
 /* Threading -------------------------------------------------------------------------------------------------------- */
 
 # include <pthread.h>
+# include <semaphore.h>
 
 typedef pthread_mutex_t kpl_mutex_t;
+typedef sem_t           kpl_semaphore_t;
 typedef pthread_t       kpl_thread_t;
 
 /* @todo Allow for mutex attributes */
@@ -52,6 +54,24 @@ void klog_platform_mutex_lock(
 );
 void klog_platform_mutex_unlock(
     kpl_mutex_t* p_mutex
+);
+
+/* @todo Allow for pshared parameter to denote inter-process sharing */
+void klog_platform_semaphore_initialize(
+    kpl_semaphore_t* p_semaphore,
+    uint32_t         count
+);
+void klog_platform_semaphore_deinitialize(
+    kpl_semaphore_t* p_semaphore
+);
+void klog_platform_semaphore_wait(
+    kpl_semaphore_t* p_semaphore
+);
+void klog_platform_semaphore_signal(
+    kpl_semaphore_t* p_semaphore
+);
+int klog_platform_semaphore_value_get(
+    kpl_semaphore_t* p_semaphore
 );
 
 /* @todo Allow for attributes upon thread creation */

--- a/src/klog/klog_platform.h
+++ b/src/klog/klog_platform.h
@@ -88,7 +88,7 @@ void klog_platform_thread_join(
 );
 
 /* Microsecond sleep */
-void sleep_usec(
+void klog_platform_sleep_usec(
     uint32_t usec
 );
 

--- a/src/klog/klog_platform.h
+++ b/src/klog/klog_platform.h
@@ -38,53 +38,53 @@ procid_t klog_platform_get_current_thread_id(
 # include <pthread.h>
 # include <semaphore.h>
 
-typedef pthread_mutex_t kpl_mutex_t;
-typedef sem_t           kpl_semaphore_t;
-typedef pthread_t       kpl_thread_t;
+typedef pthread_mutex_t klog_platform_mutex_t;
+typedef sem_t           klog_platform_semaphore_t;
+typedef pthread_t       klog_platform_thread_t;
 
 /* @todo Allow for mutex attributes */
 void klog_platform_mutex_initialize(
-    kpl_mutex_t* p_mutex
+    klog_platform_mutex_t* p_mutex
 );
 void klog_platform_mutex_deinitialize(
-    kpl_mutex_t* p_mutex
+    klog_platform_mutex_t* p_mutex
 );
 void klog_platform_mutex_lock(
-    kpl_mutex_t* p_mutex
+    klog_platform_mutex_t* p_mutex
 );
 void klog_platform_mutex_unlock(
-    kpl_mutex_t* p_mutex
+    klog_platform_mutex_t* p_mutex
 );
 
 /* @todo Allow for pshared parameter to denote inter-process sharing */
 void klog_platform_semaphore_initialize(
-    kpl_semaphore_t* p_semaphore,
-    uint32_t         count
+    klog_platform_semaphore_t* p_semaphore,
+    uint32_t                   count
 );
 void klog_platform_semaphore_deinitialize(
-    kpl_semaphore_t* p_semaphore
+    klog_platform_semaphore_t* p_semaphore
 );
 void klog_platform_semaphore_wait(
-    kpl_semaphore_t* p_semaphore
+    klog_platform_semaphore_t* p_semaphore
 );
 void klog_platform_semaphore_signal(
-    kpl_semaphore_t* p_semaphore
+    klog_platform_semaphore_t* p_semaphore
 );
 int klog_platform_semaphore_value_get(
-    kpl_semaphore_t* p_semaphore
+    klog_platform_semaphore_t* p_semaphore
 );
 
 /* @todo Allow for attributes upon thread creation */
 void klog_platform_thread_create(
-    kpl_thread_t* p_thread,
-    void* (*      thread_body)(
+    klog_platform_thread_t* p_thread,
+    void* (*                thread_body)(
         void*
     ),
-    void*         p_arg
+    void*                   p_arg
 );
 void klog_platform_thread_join(
-    kpl_thread_t* p_thread,
-    void**        p_ret
+    klog_platform_thread_t* p_thread,
+    void**                  p_ret
 );
 
 /* Microsecond sleep */

--- a/src/klog/klog_platform.h
+++ b/src/klog/klog_platform.h
@@ -67,6 +67,11 @@ void klog_platform_thread_join(
     void**        p_ret
 );
 
+/* Microsecond sleep */
+void sleep_usec(
+    uint32_t usec
+);
+
 /* Filenames -------------------------------------------------------------------------------------------------------- */
 
 # include <libgen.h> /* For basename() */

--- a/src/klog/klog_platform.h
+++ b/src/klog/klog_platform.h
@@ -20,7 +20,7 @@
 
 /* Thread / Process ID ---------------------------------------------------------------------------------------------- */
 
-# include <unistd.h> /* For pid_t */
+# include <unistd.h>      /* For pid_t */
 # include <sys/syscall.h> /* For syscall() */
 
 # ifndef SYS_gettid
@@ -31,6 +31,40 @@ typedef pid_t procid_t;
 
 procid_t klog_platform_get_current_thread_id(
     void
+);
+
+/* Threading -------------------------------------------------------------------------------------------------------- */
+
+# include <pthread.h>
+
+typedef pthread_mutex_t kpl_mutex_t;
+typedef pthread_t       kpl_thread_t;
+
+/* @todo Allow for mutex attributes */
+void klog_platform_mutex_initialize(
+    kpl_mutex_t* p_mutex
+);
+void klog_platform_mutex_deinitialize(
+    kpl_mutex_t* p_mutex
+);
+void klog_platform_mutex_lock(
+    kpl_mutex_t* p_mutex
+);
+void klog_platform_mutex_unlock(
+    kpl_mutex_t* p_mutex
+);
+
+/* @todo Allow for attributes upon thread creation */
+void klog_platform_thread_create(
+    kpl_thread_t* p_thread,
+    void* (*      thread_body)(
+        void*
+    ),
+    void*         p_arg
+);
+void klog_platform_thread_join(
+    kpl_thread_t* p_thread,
+    void**        p_ret
 );
 
 /* Filenames -------------------------------------------------------------------------------------------------------- */
@@ -84,6 +118,6 @@ timepoint_t klog_platform_get_current_timepoint(
     void
 );
 
-#endif
+#endif /* __linux__ */
 
 #endif /* KLOG_PLATFORM_INCLUDED */

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -43,6 +43,8 @@ extern struct KlogState {
     uint32_t message_element_producer_idx;
     uint32_t message_element_consumer_idx;
     uint32_t message_element_count;
+    uint32_t message_produced_total_count;
+    uint32_t message_consumed_total_count;
 
     uint32_t prefix_file_size;
     char*    b_prefixes_file;

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -59,6 +59,7 @@ extern struct KlogState {
     bool is_initialized;
 
     kpl_thread_t* b_threads;
+    kpl_mutex_t*  p_mutex_deinitialize;
     kpl_mutex_t*  p_mutex_formatted_messages;
     kpl_mutex_t*  p_mutex_file;
     kpl_mutex_t*  p_mutex_console;

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -60,6 +60,7 @@ extern struct KlogState {
 
     uint32_t* b_message_levels;
 
+    char* filename_string;
     FILE* p_file;
 
     bool is_initialized;

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -62,11 +62,13 @@ extern struct KlogState {
 
     bool is_initialized;
 
-    kpl_thread_t* b_threads;
-    kpl_mutex_t*  p_mutex_deinitialize;
-    kpl_mutex_t*  p_mutex_hot_shared;
-    kpl_mutex_t*  p_mutex_hot_producer;
-    kpl_mutex_t*  p_mutex_hot_consumer;
+    kpl_thread_t*    b_threads;
+    kpl_mutex_t*     p_mutex_deinitialize;
+    kpl_mutex_t*     p_mutex_shared;
+    kpl_mutex_t*     p_mutex_producer;
+    kpl_mutex_t*     p_mutex_consumer;
+    kpl_semaphore_t* p_semaphore_messages_empty;
+    kpl_semaphore_t* p_semaphore_messages_full;
 } g_klog_state;
 
 #endif /* KLOG_STATE_INCLUDED */

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -39,8 +39,10 @@ extern struct KlogState {
     char* b_level_strings;
     char* b_level_strings_colored;
 
-    uint32_t message_element_producer_idx; /* @todo rename this to denote that it is for producing messages */
-    uint32_t message_element_count;        /* @todo rename to denote that this is the max number of messages (the number our buffer can support) */
+    uint32_t message_unconsumed_count;
+    uint32_t message_element_producer_idx;
+    uint32_t message_element_consumer_idx;
+    uint32_t message_element_count;
 
     uint32_t prefix_file_size;
     char*    b_prefixes_file;

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -65,13 +65,13 @@ extern struct KlogState {
 
     bool is_initialized;
 
-    kpl_thread_t*    b_threads;
-    kpl_mutex_t*     p_mutex_deinitialize;
-    kpl_mutex_t*     p_mutex_shared;
-    kpl_mutex_t*     p_mutex_producer;
-    kpl_mutex_t*     p_mutex_consumer;
-    kpl_semaphore_t* p_semaphore_messages_empty;
-    kpl_semaphore_t* p_semaphore_messages_full;
+    klog_platform_thread_t*    b_threads;
+    klog_platform_mutex_t*     p_mutex_deinitialize;
+    klog_platform_mutex_t*     p_mutex_shared;
+    klog_platform_mutex_t*     p_mutex_producer;
+    klog_platform_mutex_t*     p_mutex_consumer;
+    klog_platform_semaphore_t* p_semaphore_messages_empty;
+    klog_platform_semaphore_t* p_semaphore_messages_full;
 } g_klog_state;
 
 #endif /* KLOG_STATE_INCLUDED */

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -60,7 +60,7 @@ extern struct KlogState {
 
     uint32_t* b_message_levels;
 
-    char* filename_string;
+    char* s_filename;
     FILE* p_file;
 
     bool is_initialized;

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -39,8 +39,8 @@ extern struct KlogState {
     char* b_level_strings;
     char* b_level_strings_colored;
 
-    uint32_t message_element_idx;   /* @todo rename this to denote that it is for producing messages */
-    uint32_t message_element_count; /* @todo rename to denote that this is the max number of messages (the number our buffer can support) */
+    uint32_t message_element_producer_idx; /* @todo rename this to denote that it is for producing messages */
+    uint32_t message_element_count;        /* @todo rename to denote that this is the max number of messages (the number our buffer can support) */
 
     uint32_t prefix_file_size;
     char*    b_prefixes_file;

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -56,6 +56,8 @@ extern struct KlogState {
     uint32_t message_formatted_max_size;
     char*    b_messages_formatted;
 
+    uint32_t* b_message_levels;
+
     FILE* p_file;
 
     bool is_initialized;

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -64,9 +64,9 @@ extern struct KlogState {
 
     kpl_thread_t* b_threads;
     kpl_mutex_t*  p_mutex_deinitialize;
-    kpl_mutex_t*  p_mutex_formatted_messages;
-    kpl_mutex_t*  p_mutex_file;
-    kpl_mutex_t*  p_mutex_console;
+    kpl_mutex_t*  p_mutex_hot_shared;
+    kpl_mutex_t*  p_mutex_hot_producer;
+    kpl_mutex_t*  p_mutex_hot_consumer;
 } g_klog_state;
 
 #endif /* KLOG_STATE_INCLUDED */

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -12,6 +12,7 @@
 #include <stdio.h>
 
 #include "klog/klog.h"
+#include "./klog_platform.h"
 
 /**
  * @brief This represents the initial configuraton as set by the user
@@ -38,8 +39,8 @@ extern struct KlogState {
     char* b_level_strings;
     char* b_level_strings_colored;
 
-    uint32_t message_element_idx;
-    uint32_t message_element_count;
+    uint32_t message_element_idx;   /* @todo rename this to denote that it is for producing messages */
+    uint32_t message_element_count; /* @todo rename to denote that this is the max number of messages (the number our buffer can support) */
 
     uint32_t prefix_file_size;
     char*    b_prefixes_file;
@@ -56,6 +57,11 @@ extern struct KlogState {
     FILE* p_file;
 
     bool is_initialized;
+
+    kpl_thread_t* b_threads;
+    kpl_mutex_t*  p_mutex_formatted_messages;
+    kpl_mutex_t*  p_mutex_file;
+    kpl_mutex_t*  p_mutex_console;
 } g_klog_state;
 
 #endif /* KLOG_STATE_INCLUDED */

--- a/src/klog/pt/pt-klog_sync_vs_async.c
+++ b/src/klog/pt/pt-klog_sync_vs_async.c
@@ -12,7 +12,10 @@ void run(
     const KlogFormatInfo format_info = { 4, 20, 0, false, false };
     const KlogAsyncInfo  async_info  = { 100, num_threads };
     const KlogFileInfo   file_info   = { KLOG_LEVEL_TRACE, "klog_sync_vs_async" };
-    klog_initialize(1, format_info, &async_info, NULL, &file_info, NULL);
+
+    const KlogAsyncInfo* p_async_info = (num_threads > 0) ? &async_info : NULL;
+
+    klog_initialize(1, format_info, p_async_info, NULL, &file_info, NULL);
 
     const KlogLoggerHandle* p_handle = klog_logger_create("name", 4);
     klog_logger_level_set(p_handle, KLOG_LEVEL_TRACE);

--- a/src/klog/pt/pt-klog_sync_vs_async.c
+++ b/src/klog/pt/pt-klog_sync_vs_async.c
@@ -1,0 +1,50 @@
+#include <stdio.h>
+#include <stdint.h>
+
+#include "klog/klog.h"
+#include "../klog_platform.h"
+
+void run(
+    const uint32_t num_threads
+) {
+    const uint32_t num_logs = 50000;
+
+    const KlogFormatInfo format_info = { 4, 20, 0, false, false };
+    const KlogAsyncInfo  async_info  = { 100, num_threads };
+    const KlogFileInfo   file_info   = { KLOG_LEVEL_TRACE, "klog_sync_vs_async" };
+    klog_initialize(1, format_info, &async_info, NULL, &file_info, NULL);
+
+    const KlogLoggerHandle* p_handle = klog_logger_create("name", 4);
+    klog_logger_level_set(p_handle, KLOG_LEVEL_TRACE);
+
+    const timepoint_t start = klog_platform_get_current_timepoint();
+    for (uint32_t idx_message = 0; idx_message < num_logs; ++idx_message) {
+        klog_trace(p_handle, "hello");
+    }
+    const timepoint_t end = klog_platform_get_current_timepoint();
+
+    klog_deinitialize();
+
+    const double start_seconds        = start.second + ((double)start.microsecond / 1000000.0);
+    const double end_seconds          = end.second + ((double)end.microsecond / 1000000.0);
+    const double duration_sec         = end_seconds - start_seconds;
+    const double duration_sec_per_log = duration_sec / num_logs;
+
+    printf(
+        "%d logs with %d backing threads took %02.9f seconds (%.9f per log)\n",
+        num_logs,
+        num_threads,
+        duration_sec,
+        duration_sec_per_log
+    );
+}
+
+int main(
+    void
+) {
+    for (uint32_t i = 0; i < 5; ++i) {
+        run(i);
+    }
+
+    return 0;
+}

--- a/src/klog/ut/ut-klog_alloc_callback_counts.c
+++ b/src/klog/ut/ut-klog_alloc_callback_counts.c
@@ -56,7 +56,7 @@ int check(
     klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, NULL, NULL, NULL, &alloc_info);
 
     /* check post initialization values - not allocating threads here */
-    const uint32_t alloc_counter_init_expected = 15;
+    const uint32_t alloc_counter_init_expected = 17;
     if (g_alloc_counter != alloc_counter_init_expected) {
         printf("Alloc counter is %d after initialization when it should be %d\n", g_alloc_counter, alloc_counter_init_expected);
         return 1;
@@ -100,7 +100,7 @@ int check(
         printf("Alloc counter is %d after deinitializtion when it should be %d\n", g_alloc_counter, alloc_counter_deinit_expected);
         return 1;
     }
-    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 15; /* not freeing threads here  */
+    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 17; /* not freeing threads here  */
     if (g_free_counter != free_counter_deinit_expected) {
         printf("Free counter is %d after deinitialization when it should be %d\n", g_free_counter, free_counter_deinit_expected);
         return 1;

--- a/src/klog/ut/ut-klog_alloc_callback_counts.c
+++ b/src/klog/ut/ut-klog_alloc_callback_counts.c
@@ -51,12 +51,13 @@ int check(
     const uint32_t max_number_loggers = 2;
     const uint32_t max_name_length    = 3;
 
+    const KlogAsyncInfo async_info = { 20, 5 };
     const KlogAllocInfo alloc_info = { &malloc_wrapper, &free_wrapper };
 
-    klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, NULL, NULL, NULL, &alloc_info);
+    klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, &async_info, NULL, NULL, &alloc_info);
 
     /* check post initialization values - not allocating threads here */
-    const uint32_t alloc_counter_init_expected = 17;
+    const uint32_t alloc_counter_init_expected = 18;
     if (g_alloc_counter != alloc_counter_init_expected) {
         printf("Alloc counter is %d after initialization when it should be %d\n", g_alloc_counter, alloc_counter_init_expected);
         return 1;
@@ -100,7 +101,7 @@ int check(
         printf("Alloc counter is %d after deinitializtion when it should be %d\n", g_alloc_counter, alloc_counter_deinit_expected);
         return 1;
     }
-    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 17; /* not freeing threads here  */
+    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 18;
     if (g_free_counter != free_counter_deinit_expected) {
         printf("Free counter is %d after deinitialization when it should be %d\n", g_free_counter, free_counter_deinit_expected);
         return 1;

--- a/src/klog/ut/ut-klog_alloc_callback_counts.c
+++ b/src/klog/ut/ut-klog_alloc_callback_counts.c
@@ -51,18 +51,27 @@ int check(
     const uint32_t max_number_loggers = 2;
     const uint32_t max_name_length    = 3;
 
-    const KlogAsyncInfo async_info = { 20, 5 };
-    const KlogAllocInfo alloc_info = { &malloc_wrapper, &free_wrapper };
+    const KlogAsyncInfo   async_info   = { 20, 5 };
+    const KlogConsoleInfo console_info = { KLOG_LEVEL_TRACE, true };
+    const KlogFileInfo    file_info    = { KLOG_LEVEL_TRACE, "alloc_callback_counts" };
+    const KlogAllocInfo   alloc_info   = { &malloc_wrapper, &free_wrapper };
 
-    klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, &async_info, NULL, NULL, &alloc_info);
+    klog_initialize(
+        max_number_loggers,
+        (KlogFormatInfo) { max_name_length, 10, 0, false, false },
+        &async_info,
+        &console_info,
+        &file_info,
+        &alloc_info
+    );
 
     /* check post initialization values - not allocating threads here */
-    const uint32_t alloc_counter_init_expected = 18;
+    const uint32_t alloc_counter_init_expected = 20;
     if (g_alloc_counter != alloc_counter_init_expected) {
         printf("Alloc counter is %d after initialization when it should be %d\n", g_alloc_counter, alloc_counter_init_expected);
         return 1;
     }
-    const uint32_t free_counter_init_expected = 0;
+    const uint32_t free_counter_init_expected = 1; /* for the filename initialization */
     if (g_free_counter != free_counter_init_expected) {
         printf("Free counter is %d after initialization when it should be %d\n", g_free_counter, free_counter_init_expected);
         return 1;
@@ -101,7 +110,7 @@ int check(
         printf("Alloc counter is %d after deinitializtion when it should be %d\n", g_alloc_counter, alloc_counter_deinit_expected);
         return 1;
     }
-    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 18;
+    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 19;
     if (g_free_counter != free_counter_deinit_expected) {
         printf("Free counter is %d after deinitialization when it should be %d\n", g_free_counter, free_counter_deinit_expected);
         return 1;

--- a/src/klog/ut/ut-klog_alloc_callback_counts.c
+++ b/src/klog/ut/ut-klog_alloc_callback_counts.c
@@ -56,7 +56,7 @@ int check(
     klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, NULL, NULL, NULL, &alloc_info);
 
     /* check post initialization values - not allocating threads here */
-    const uint32_t alloc_counter_init_expected = 14;
+    const uint32_t alloc_counter_init_expected = 15;
     if (g_alloc_counter != alloc_counter_init_expected) {
         printf("Alloc counter is %d after initialization when it should be %d\n", g_alloc_counter, alloc_counter_init_expected);
         return 1;
@@ -100,7 +100,7 @@ int check(
         printf("Alloc counter is %d after deinitializtion when it should be %d\n", g_alloc_counter, alloc_counter_deinit_expected);
         return 1;
     }
-    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 14; /* not freeing threads here  */
+    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 15; /* not freeing threads here  */
     if (g_free_counter != free_counter_deinit_expected) {
         printf("Free counter is %d after deinitialization when it should be %d\n", g_free_counter, free_counter_deinit_expected);
         return 1;

--- a/src/klog/ut/ut-klog_alloc_callback_counts.c
+++ b/src/klog/ut/ut-klog_alloc_callback_counts.c
@@ -56,7 +56,7 @@ int check(
     klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, NULL, NULL, NULL, &alloc_info);
 
     /* check post initialization values - not allocating threads here */
-    const uint32_t alloc_counter_init_expected = 13;
+    const uint32_t alloc_counter_init_expected = 14;
     if (g_alloc_counter != alloc_counter_init_expected) {
         printf("Alloc counter is %d after initialization when it should be %d\n", g_alloc_counter, alloc_counter_init_expected);
         return 1;
@@ -100,7 +100,7 @@ int check(
         printf("Alloc counter is %d after deinitializtion when it should be %d\n", g_alloc_counter, alloc_counter_deinit_expected);
         return 1;
     }
-    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 13; /* not freeing threads here  */
+    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 14; /* not freeing threads here  */
     if (g_free_counter != free_counter_deinit_expected) {
         printf("Free counter is %d after deinitialization when it should be %d\n", g_free_counter, free_counter_deinit_expected);
         return 1;

--- a/src/klog/ut/ut-klog_alloc_callback_counts.c
+++ b/src/klog/ut/ut-klog_alloc_callback_counts.c
@@ -55,8 +55,8 @@ int check(
 
     klog_initialize(max_number_loggers, (KlogFormatInfo) { max_name_length, 10, 0, false, false }, NULL, NULL, NULL, &alloc_info);
 
-    /* check post initialization values */
-    const uint32_t alloc_counter_init_expected = 10;
+    /* check post initialization values - not allocating threads here */
+    const uint32_t alloc_counter_init_expected = 13;
     if (g_alloc_counter != alloc_counter_init_expected) {
         printf("Alloc counter is %d after initialization when it should be %d\n", g_alloc_counter, alloc_counter_init_expected);
         return 1;
@@ -100,7 +100,7 @@ int check(
         printf("Alloc counter is %d after deinitializtion when it should be %d\n", g_alloc_counter, alloc_counter_deinit_expected);
         return 1;
     }
-    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 10;
+    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 13; /* not freeing threads here  */
     if (g_free_counter != free_counter_deinit_expected) {
         printf("Free counter is %d after deinitialization when it should be %d\n", g_free_counter, free_counter_deinit_expected);
         return 1;

--- a/src/klog/ut/ut-klog_async_message_ordering.c
+++ b/src/klog/ut/ut-klog_async_message_ordering.c
@@ -1,0 +1,148 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "klog/klog.h"
+
+#include "../klog_state.c"
+
+/*              00+               123456789    */
+/*              10+                        012 */
+const char*    g_prefix        = "[X] [debug] ";
+const uint32_t g_prefix_length = 12;
+
+const uint32_t g_num_messages        = 5000;
+const uint32_t g_message_digit_count = 4;
+char*          g_message_buffer      = "0000\n"; /* 1 character for each digit, and a newline */
+
+char* populate_file(
+    void
+) {
+    /* Initialize klog with async and file information */
+    KlogFormatInfo format_info = { 1, 4, 0, false, false };
+    KlogAsyncInfo  async_info  = { 5000, 4 };
+    KlogFileInfo   file_info   = { KLOG_LEVEL_TRACE, "async_message_ordering" };
+    klog_initialize(1, format_info, &async_info, NULL, &file_info, NULL);
+
+    /* Create a logger and log the messages */
+    const KlogLoggerHandle* p_handle = klog_logger_create("X", 1);
+    klog_logger_level_set(p_handle, KLOG_LEVEL_TRACE);
+    for (uint32_t idx_message = 0; idx_message < g_num_messages; ++idx_message) {
+        klog(p_handle, KLOG_LEVEL_DEBUG, "%04d", idx_message);
+    }
+
+    /* Copy the filename and return it for later use */
+    const uint32_t filename_length = strlen(g_klog_state.filename_string);
+    char*          filename_copy   = malloc(filename_length + 1);
+    filename_copy[filename_length] = '\0'; /* null terminator */
+    memcpy(filename_copy, g_klog_state.filename_string, filename_length);
+    printf("Filename =  %s\n", filename_copy);
+
+    /* Deinitialize klog */
+    klog_deinitialize();
+
+    return filename_copy;
+}
+
+int check(
+    void
+) {
+    /* Populate things with klog */
+    char* filename = populate_file();
+    if (!filename) {
+        printf("Klog initialize did not create a valid filename for some reason?\n");
+        return 1;
+    }
+
+    /* Open the file */
+    FILE* const p_file = fopen(filename, "r");
+    if (!p_file) {
+        printf("Couldn't open file at %s\n", filename);
+        return 1;
+    }
+
+    /* Get the size of the file */
+    if (fseek(p_file, 0, SEEK_END) != 0) {
+        printf("Problem when invoking fseek to put cursor at the end for getting the file size\n");
+        return 1;
+    }
+    const int32_t file_size = ftell(p_file);
+    if (file_size < 0) {
+        printf("Problem when invoking ftell to get the file size\n");
+        return 1;
+    }
+    const uint32_t line_size          = g_prefix_length + g_message_digit_count + 1; /* 12 for prefix, 4 for the digits + 1 for newline */
+    const uint32_t file_size_expected = line_size * g_num_messages;
+    if (file_size != file_size_expected) {
+        printf("Actual file size (%d) != expecte file size (%d)\n", file_size, file_size_expected);
+        return 1;
+    }
+
+    /* Reset the cursor so we can begin reading */
+    if (fseek(p_file, 0, SEEK_SET) != 0) {
+        printf("Problem when invoking fseek to put cursor at the beginning to prep for reading the file contents\n");
+        return 1;
+    }
+
+    /* Read each line and validate the contents */
+    char* buffer = malloc(line_size);
+    for (uint32_t idx_message = 0; idx_message < g_num_messages; ++idx_message) {
+        fread(buffer, line_size, 1, p_file); /* Read line_size "items", each of size 1 byte */
+        /* printf("Read line %d: \"%.*s\"\n", idx_message, line_size, buffer); */
+
+        /* Compare prefixes */
+        if (strncmp(buffer, g_prefix, g_prefix_length) != 0) {
+            printf(
+                "Line %d does not contain the prefix: \"%.*s\" != \"%.*s\"\n",
+                idx_message,
+                g_prefix_length,
+                buffer,
+                g_prefix_length,
+                g_prefix
+            );
+            return 1;
+        }
+
+        /* Compare actual value - first create the string representing the current formatted index */
+        char* b_digits = malloc(g_message_digit_count + 1); /* Need space for sprintf's null char */
+        sprintf(b_digits, "%04d", idx_message);
+        if (strncmp(buffer + g_prefix_length, b_digits, g_message_digit_count) != 0) {
+            printf(
+                "Line %d does not contain the digits: \"%.*s\" != \"%.*s\"\n",
+                idx_message,
+                g_message_digit_count,
+                buffer + g_prefix_length,
+                g_message_digit_count,
+                b_digits
+            );
+            return 1;
+        }
+        free(b_digits);
+
+        /* Check newline at final character */
+        if (buffer[line_size - 1] != '\n') {
+            printf(
+                "Line %d does not contain newline at final character index %d: '%c' (%d)\n",
+                idx_message,
+                line_size - 1,
+                buffer[line_size - 1],
+                buffer[line_size - 1]
+            );
+            return 1;
+        }
+    }
+
+    /* Free the buffer, global filename, and close the file */
+    free(buffer);
+    fclose(p_file);
+    free(filename);
+
+    return 0;
+}
+
+int main(
+    void
+) {
+    return check();
+}

--- a/src/klog/ut/ut-klog_async_message_ordering.c
+++ b/src/klog/ut/ut-klog_async_message_ordering.c
@@ -33,10 +33,10 @@ char* populate_file(
     }
 
     /* Copy the filename and return it for later use */
-    const uint32_t filename_length = strlen(g_klog_state.filename_string);
+    const uint32_t filename_length = strlen(g_klog_state.s_filename);
     char*          filename_copy   = malloc(filename_length + 1);
     filename_copy[filename_length] = '\0'; /* null terminator */
-    memcpy(filename_copy, g_klog_state.filename_string, filename_length);
+    memcpy(filename_copy, g_klog_state.s_filename, filename_length);
     printf("Filename =  %s\n", filename_copy);
 
     /* Deinitialize klog */

--- a/src/klog/ut/ut-klog_deinitialize.c
+++ b/src/klog/ut/ut-klog_deinitialize.c
@@ -39,6 +39,8 @@ int check(
     KlogFormatInfo  format_info  = { 6, 100, 10, true, true };
     KlogConsoleInfo console_info = { KLOG_LEVEL_INFO, true };
     KlogFileInfo    file_info    = { KLOG_LEVEL_TRACE, "BASIC\tPREFIX" };
+
+    printf("Initializing klog\n");
     klog_initialize(4, format_info, &async_info, &console_info, &file_info, NULL);
 
     /* Ensure allocation/free callbacks were defaulted correctly */
@@ -68,7 +70,9 @@ int check(
     }
 
     /* Deinitialize */
+    printf("De-initializing klog\n");
     klog_deinitialize();
+    printf("De-initializing klog - DONE\n");
 
     /* Check that we **are** equivelant to null */
     if (memcmp(&g_klog_config, &klog_config_empty, sizeof(klog_config_empty)) != 0) {

--- a/src/klog/ut/ut-klog_format_prefix.c
+++ b/src/klog/ut/ut-klog_format_prefix.c
@@ -19,7 +19,7 @@ int length_0(
     const char* s = "[hello] [fatal] ";
     /*  00+          123456789          */
     /*  10+                   0123456   */
-    const uint32_t expected = strlen(s);
+    const uint32_t expected = strlen(s) + 1;
 
     const uint32_t actual = klog_format_prefix_length_get(false, false, 5, false, 0);
 
@@ -38,7 +38,7 @@ int length_color(
     /*  00+          123456789                              */
     /*  10+                   012345    6789                */
     /*  20+                                 01234    5678   */
-    const uint32_t expected = strlen(s);
+    const uint32_t expected = strlen(s) + 1;
 
     const uint32_t actual = klog_format_prefix_length_get(false, false, 10, true, 0);
 
@@ -54,7 +54,7 @@ int length_source_location(
     void
 ) {
     const char*    s        = "[hel] [\x1b[33mWARN \x1b[0m] [aaaaBBBBccccDDDD:9999] ";
-    const uint32_t expected = strlen(s);
+    const uint32_t expected = strlen(s) + 1;
 
     const uint32_t actual = klog_format_prefix_length_get(false, false, 3, true, 16);
 
@@ -70,7 +70,7 @@ int length_timestamp(
     void
 ) {
     const char*    s        = "ddd:hh:mm:ss:uuuuuu [123456789] [debug] [aaaabbbb:9999] ";
-    const uint32_t expected = strlen(s);
+    const uint32_t expected = strlen(s) + 1;
 
     const uint32_t actual = klog_format_prefix_length_get(false, true, 9, false, 8);
 
@@ -86,7 +86,7 @@ int length_thread_id(
     void
 ) {
     const char*    s        = "1234567 ddd:hh:mm:ss:uuuuuu [123456789] [warn ] ";
-    const uint32_t expected = strlen(s);
+    const uint32_t expected = strlen(s) + 1;
 
     const uint32_t actual = klog_format_prefix_length_get(true, true, 9, false, 0);
 
@@ -102,7 +102,7 @@ int length_all(
     void
 ) {
     const char*    s        = "1234567 ddd:hh:mm:ss:uuuuuu [logger] [\x1b[31mERROR\x1b[0m] [12345  :   1] ";
-    const uint32_t expected = strlen(s);
+    const uint32_t expected = strlen(s) + 1;
 
     const uint32_t actual = klog_format_prefix_length_get(true, true, 6, true, 7);
 
@@ -117,24 +117,28 @@ int length_all(
 int none(
     void
 ) {
-    KlogString result = klog_format_message_prefix(NULL, NULL, NULL, NULL, NULL, NULL);
+    char*      buffer = malloc(1);
+    KlogString result = klog_format_message_prefix(buffer, NULL, NULL, NULL, NULL, NULL);
 
-    if (result.length != 0) {
-        printf("Resulting KlogString's length should be 0 when nothing is given to the prefix\n");
+    if (result.length != 1) {
+        printf("Resulting KlogString's length should be 1 when nothing is given to the prefix so we can have the null terminator\n");
         return 1;
     }
 
-    if (result.s != NULL) {
-        printf("Resulting KlogString's string should be NULL when nothing is given to the prefix\n");
+    if (result.s != buffer) {
+        printf("Resulting KlogString's string should be the same as the input buffer\n");
         return 1;
     }
 
+    free(buffer);
     return 0;
 }
 
 int empty_strings(
     void
 ) {
+    char* buffer = malloc(1);
+
     const char* s_time      = "mustard!";
     KlogString  packed_time = { 0, s_time };
 
@@ -147,17 +151,19 @@ int empty_strings(
     const char* s_source_location      = "googoo";
     KlogString  packed_source_location = { 0, s_source_location };
 
-    KlogString result = klog_format_message_prefix(NULL, NULL, &packed_time, &packed_name, &packed_level, &packed_source_location);
+    KlogString result = klog_format_message_prefix(buffer, NULL, &packed_time, &packed_name, &packed_level, &packed_source_location);
 
-    if (result.length != 0) {
-        printf("Resulting KlogString's length should be 0 when nothing is given to the prefix\n");
+    if (result.length != 1) {
+        printf("Resulting KlogString's length should be 1 when nothing is given to the prefix\n");
         return 1;
     }
 
-    if (result.s != NULL) {
-        printf("Resulting KlogString's string should be NULL when nothing is given to the prefix\n");
+    if (result.s != buffer) {
+        printf("Resulting KlogString's string should be the same as the input buffer\n");
         return 1;
     }
+
+    free(buffer);
 
     return 0;
 }
@@ -165,10 +171,10 @@ int empty_strings(
 int just_thread_id(
     void
 ) {
-    const uint32_t length_expected = 8;
+    const uint32_t length_expected = 9;
     const uint32_t thread_id       = 1234;
 
-    char*      s      = malloc(length_expected + 1);
+    char*      s      = malloc(length_expected);
     KlogString result = klog_format_message_prefix(s, &thread_id, NULL, NULL, NULL, NULL);
 
     if (result.length != length_expected) {
@@ -211,8 +217,8 @@ int just_time(
     const char*    s_provided      = "0123456789";
     KlogString     packed_time     = { length_provided, s_provided };
 
-    const uint32_t length_expected = length_provided + 1;
-    char*          s               = malloc(length_expected + 1);
+    const uint32_t length_expected = length_provided + 1 + 1; /* +1 for space, +1 for null char */
+    char*          s               = malloc(length_expected);
     KlogString     result          = klog_format_message_prefix(s, NULL, &packed_time, NULL, NULL, NULL);
 
     if (result.length != length_expected) {
@@ -255,8 +261,8 @@ int just_name(
     const char*    s_provided      = "LOGGER";
     KlogString     packed_name     = { length_provided, s_provided };
 
-    const uint32_t length_expected = length_provided + 3;
-    char*          s               = malloc(length_expected + 1);
+    const uint32_t length_expected = length_provided + 3 + 1; /* +3 for space and square brackets, +1 for null char */
+    char*          s               = malloc(length_expected);
     KlogString     result          = klog_format_message_prefix(s, NULL, NULL, &packed_name, NULL, NULL);
 
     if (result.length != length_expected) {
@@ -295,12 +301,13 @@ int just_name(
 int just_level(
     void
 ) {
+    /*                                12345678901234567890 */
     const uint32_t length_provided = 20;
     const char*    s_provided      = "AAAAbbbbCCCCdddd    ";
     KlogString     packed_level    = { length_provided, s_provided };
 
-    const uint32_t length_expected = length_provided + 3;
-    char*          s               = malloc(length_expected + 1);
+    const uint32_t length_expected = length_provided + 3 + 1; /* +3 for square brackets and space, +1 for null char*/
+    char*          s               = malloc(length_expected);
     KlogString     result          = klog_format_message_prefix(s, NULL, NULL, NULL, &packed_level, NULL);
 
     if (result.length != length_expected) {
@@ -343,8 +350,8 @@ int just_source_location(
     const char*    s_provided             = "X:2";
     KlogString     packed_source_location = { length_provided, s_provided };
 
-    const uint32_t length_expected = length_provided + 3;
-    char*          s               = malloc(length_expected + 1);
+    const uint32_t length_expected = length_provided + 3 + 1; /* +3 for square brackets and space, +1 for null char */
+    char*          s               = malloc(length_expected);
     KlogString     result          = klog_format_message_prefix(s, NULL, NULL, NULL, NULL, &packed_source_location);
 
     if (result.length != length_expected) {
@@ -393,8 +400,8 @@ int subset_1(
     const char*    s_name               = " HOHO xD Rawr ";
     KlogString     packed_name          = { name_length_provided, s_name };
 
-    const uint32_t length_expected = 8 + (time_length_provided + 1) + (name_length_provided + 3);
-    char*          s               = malloc(length_expected + 1);
+    const uint32_t length_expected = 8 + (time_length_provided + 1) + (name_length_provided + 3) + 1;
+    char*          s               = malloc(length_expected);
     KlogString     result          = klog_format_message_prefix(s, &thread_id, &packed_time, &packed_name, NULL, NULL);
 
     if (result.length != length_expected) {
@@ -441,8 +448,8 @@ int subset_2(
     const char*    s_level               = "UP!";
     KlogString     packed_level          = { level_length_provided, s_level };
 
-    const uint32_t length_expected = (time_length_provided + 1) + (name_length_provided + 3) + (level_length_provided + 3);
-    char*          s               = malloc(length_expected + 1);
+    const uint32_t length_expected = (time_length_provided + 1) + (name_length_provided + 3) + (level_length_provided + 3) + 1;
+    char*          s               = malloc(length_expected);
     KlogString     result          = klog_format_message_prefix(s, NULL, &packed_time, &packed_name, &packed_level, NULL);
 
     if (result.length != length_expected) {
@@ -489,8 +496,8 @@ int subset_3(
     const char*    s_source_location               = "  hehehe  ";
     KlogString     packed_source_location          = { source_location_length_provided, s_source_location };
 
-    const uint32_t length_expected = (name_length_provided + 3) + (level_length_provided + 3) + (source_location_length_provided + 3);
-    char*          s               = malloc(length_expected + 1);
+    const uint32_t length_expected = (name_length_provided + 3) + (level_length_provided + 3) + (source_location_length_provided + 3) + 1;
+    char*          s               = malloc(length_expected);
     KlogString     result          = klog_format_message_prefix(s, NULL, NULL, &packed_name, &packed_level, &packed_source_location);
 
     if (result.length != length_expected) {
@@ -544,8 +551,8 @@ int everything(
     KlogString     packed_source_location          = { source_location_length_provided, s_source_location };
 
     const uint32_t length_expected = 8 + (time_length_provided + 1) + (name_length_provided + 3) + (level_length_provided + 3)
-        + (source_location_length_provided + 3);
-    char*      s      = malloc(length_expected + 1);
+        + (source_location_length_provided + 3) + 1;
+    char*      s      = malloc(length_expected);
     KlogString result = klog_format_message_prefix(
         s,
         &thread_id,
@@ -604,8 +611,8 @@ int shortened_strings(
     KlogString     packed_source_location          = { source_location_length_provided, s_source_location };
 
     const uint32_t length_expected = (time_length_provided + 1) + (name_length_provided + 3) + (level_length_provided + 3)
-        + (source_location_length_provided + 3);
-    char*      s      = malloc(length_expected + 1);
+        + (source_location_length_provided + 3) + 1;
+    char*      s      = malloc(length_expected);
     KlogString result = klog_format_message_prefix(
         s,
         NULL,
@@ -664,8 +671,8 @@ int nominal_parameters(
     const KlogString packed_source_location = klog_format_source_location(b_source_location, 15, s_filename, line_number);
 
     const uint32_t length_expected = 8 + (packed_time.length + 1) + (packed_name.length + 3) + (packed_level.length + 3)
-        + (packed_source_location.length + 3);
-    char*      s      = malloc(length_expected + 1);
+        + (packed_source_location.length + 3) + 1;
+    char*      s      = malloc(length_expected);
     KlogString result = klog_format_message_prefix(
         s,
         &thread_id,
@@ -735,25 +742,27 @@ int noop(
 int main(
     void
 ) {
-    return length_0()
-           || length_color()
-           || length_source_location()
-           || length_timestamp()
-           || length_thread_id()
-           || length_all()
-           || none()
-           || empty_strings()
-           || just_thread_id()
-           || just_time()
-           || just_name()
-           || just_level()
-           || just_source_location()
-           || subset_1()
-           || subset_2()
-           || subset_3()
-           || everything()
-           || shortened_strings()
-           || nominal_parameters()
-           || noop()
+    int result = length_0()
+        || length_color()
+        || length_source_location()
+        || length_timestamp()
+        || length_thread_id()
+        || length_all()
+        || none()
+        || empty_strings()
+        || just_thread_id()
+        || just_time()
+        || just_name()
+        || just_level()
+        || just_source_location()
+        || subset_1()
+        || subset_2()
+        || subset_3()
+        || everything()
+        || shortened_strings()
+        || nominal_parameters()
+        || noop()
     ;
+
+    return result;
 }

--- a/src/klog/ut/ut-klog_initialize_parameters_are_valid.c
+++ b/src/klog/ut/ut-klog_initialize_parameters_are_valid.c
@@ -50,6 +50,50 @@ int no_message_length(
     return 0;
 }
 
+int no_message_queue_elements(
+    void
+) {
+    KlogAsyncInfo async_info = { 0, 10 };
+    if (
+        klog_initialize_are_parameters_valid(
+            false,
+            10,
+            (KlogFormatInfo) { 10, 0, 0, false, false },
+            &async_info,
+            NULL,
+            NULL,
+            NULL
+        )
+    ) {
+        printf("Parameters should be invalid when KlogAsyncInfo pointer is provided but message_queue_number_elements is 0\n");
+        return 1;
+    }
+
+    return 0;
+}
+
+int no_backing_threads(
+    void
+) {
+    KlogAsyncInfo async_info = { 10, 0 };
+    if (
+        klog_initialize_are_parameters_valid(
+            false,
+            10,
+            (KlogFormatInfo) { 10, 0, 0, false, false },
+            &async_info,
+            NULL,
+            NULL,
+            NULL
+        )
+    ) {
+        printf("Parameters should be invalid when KlogAsyncInfo pointer is provided but number_backing_threads is 0\n");
+        return 1;
+    }
+
+    return 0;
+}
+
 int no_alloc_cb(
     void
 ) {
@@ -102,8 +146,10 @@ int main(
 ) {
     const int result = already_initialized()
         || no_loggers()
+        || no_logger_name_length()
         || no_message_length()
-        || no_message_length()
+        || no_message_queue_elements()
+        || no_backing_threads()
         || no_alloc_cb()
         || no_free_cb()
         || valid()

--- a/src/klog/ut/ut-klog_ring_buffer_usage.c
+++ b/src/klog/ut/ut-klog_ring_buffer_usage.c
@@ -346,15 +346,6 @@ int multiple_elements(
         return 1;
     }
 
-    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer, message_total_length)) {
-        printf(
-            "Klog formatted message buffer element 0 should be empty (cleared) after logging at info level, but instead it contains \"%.*s\"\n",
-            message_total_length,
-            g_klog_state.b_messages_formatted
-        );
-        return 1;
-    }
-
     /* Second logging statement */
 
     printf("Buffer after first log:\n");
@@ -412,15 +403,6 @@ int multiple_elements(
             "Klog console prefix buffer element 1 should contain \"%s\" after logging at trace level, but instead it contains \"%s\"\n",
             full_prefix_buffer_2,
             g_klog_state.b_prefixes_console + prefix_size
-        );
-        return 1;
-    }
-
-    if (memcmp(g_klog_state.b_messages_formatted, empty_message_buffer, message_total_length)) {
-        printf(
-            "Klog formatted message buffer element 1 should be empty (cleared) after logging at info level 2 times, but instead it contains \"%.*s\"\n",
-            message_total_length,
-            g_klog_state.b_messages_formatted + (message_total_length * 1)
         );
         return 1;
     }

--- a/src/klog/ut/ut-klog_ring_buffer_usage.c
+++ b/src/klog/ut/ut-klog_ring_buffer_usage.c
@@ -82,19 +82,19 @@ int no_async_param(
         return 1;
     }
 
-    char* full_prefix_buffer = "[dummy!] [info ] ";
-    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer, prefix_size)) {
+    char* full_prefix_buffer_dum_info = "[dummy!] [info ] ";
+    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer_dum_info, prefix_size)) {
         printf(
             "Klog file prefix buffer should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
-            full_prefix_buffer,
+            full_prefix_buffer_dum_info,
             g_klog_state.b_prefixes_file
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer_dum_info, prefix_size)) {
         printf(
             "Klog console prefix buffer should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
-            full_prefix_buffer,
+            full_prefix_buffer_dum_info,
             g_klog_state.b_prefixes_console
         );
         return 1;
@@ -184,19 +184,19 @@ int single_element(
         return 1;
     }
 
-    char* full_prefix_buffer = "[dummy123] [info ] ";
-    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer, prefix_size)) {
+    char* full_prefix_buffer_dum_info = "[dummy123] [info ] ";
+    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer_dum_info, prefix_size)) {
         printf(
             "Klog file prefix buffer should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
-            full_prefix_buffer,
+            full_prefix_buffer_dum_info,
             g_klog_state.b_prefixes_file
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer_dum_info, prefix_size)) {
         printf(
             "Klog console prefix buffer should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
-            full_prefix_buffer,
+            full_prefix_buffer_dum_info,
             g_klog_state.b_prefixes_console
         );
         return 1;
@@ -345,6 +345,10 @@ int multiple_elements(
         printf("Klog total produced message element count should be 1 after the first log\n");
         return 1;
     }
+    if (g_klog_state.b_message_levels[0] != KLOG_LEVEL_INFO) {
+        printf("Klog level buffer should contain KLOG_LEVEL_INFO at index 0 after the first log\n");
+        return 1;
+    }
     klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
     klog_platform_sleep_usec(100); /* Short sleep to allow async threads to log */
     klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
@@ -358,19 +362,19 @@ int multiple_elements(
     }
     klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
 
-    char* full_prefix_buffer = "[dum] [info ] ";
-    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer, prefix_size)) {
+    char* full_prefix_buffer_dum_info = "[dum] [info ] ";
+    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer_dum_info, prefix_size)) {
         printf(
             "Klog file prefix buffer element 0 should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
-            full_prefix_buffer,
+            full_prefix_buffer_dum_info,
             g_klog_state.b_prefixes_file
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer_dum_info, prefix_size)) {
         printf(
             "Klog console prefix buffer element 0 should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
-            full_prefix_buffer,
+            full_prefix_buffer_dum_info,
             g_klog_state.b_prefixes_console
         );
         return 1;
@@ -421,6 +425,10 @@ int multiple_elements(
     }
     if (g_klog_state.message_produced_total_count != 2) {
         printf("Klog total produced message element count should be 2 after the second log\n");
+        return 1;
+    }
+    if (g_klog_state.b_message_levels[1] != KLOG_LEVEL_DEBUG) {
+        printf("Klog level buffer should contain KLOG_LEVEL_DEBUG at index 1 after the second log\n");
         return 1;
     }
     klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
@@ -479,6 +487,10 @@ int multiple_elements(
         printf("Klog total produced message element count should be 3 after the third log\n");
         return 1;
     }
+    if (g_klog_state.b_message_levels[2] != KLOG_LEVEL_ERROR) {
+        printf("Klog level buffer should contain KLOG_LEVEL_ERROR at index 2 after the third log\n");
+        return 1;
+    }
     klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
     klog_platform_sleep_usec(1000); /* Short sleep to allow async threads to log */
     klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
@@ -512,24 +524,24 @@ int multiple_elements(
 
     /* Fourth logging statement */
 
-    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer_dum_info, prefix_size)) {
         printf(
             "Klog file prefix buffer element 0 should contain \"%s\" before logging after overflow at info level, but instead it contains \"%s\"\n",
-            full_prefix_buffer,
+            full_prefix_buffer_dum_info,
             g_klog_state.b_prefixes_file
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer_dum_info, prefix_size)) {
         printf(
             "Klog console prefix buffer element 0 should contain \"%s\" before logging after overflow at info level, but instead it contains \"%s\"\n",
-            full_prefix_buffer,
+            full_prefix_buffer_dum_info,
             g_klog_state.b_prefixes_file
         );
         return 1;
     }
 
-    klog_info(p, "test, again!");
+    klog_fatal(p, "test, again!");
 
     klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
     if (g_klog_state.message_element_producer_idx != 1) {
@@ -538,6 +550,10 @@ int multiple_elements(
     }
     if (g_klog_state.message_produced_total_count != 4) {
         printf("Klog total produced message element count should be 4 after the fourth log\n");
+        return 1;
+    }
+    if (g_klog_state.b_message_levels[0] != KLOG_LEVEL_FATAL) {
+        printf("Klog level buffer should contain KLOG_LEVEL_FATAL at index 0 after the fourth log\n");
         return 1;
     }
     klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
@@ -553,18 +569,19 @@ int multiple_elements(
     }
     klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
 
-    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer, prefix_size)) {
+    char* full_prefix_buffer_dum_fatal = "[dum] [FATAL] ";
+    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer_dum_fatal, prefix_size)) {
         printf(
             "Klog file prefix buffer element 0 should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
-            full_prefix_buffer,
+            full_prefix_buffer_dum_fatal,
             g_klog_state.b_prefixes_file
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer_dum_fatal, prefix_size)) {
         printf(
             "Klog console prefix buffer element 0 should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
-            full_prefix_buffer,
+            full_prefix_buffer_dum_fatal,
             g_klog_state.b_prefixes_console
         );
         return 1;

--- a/src/klog/ut/ut-klog_ring_buffer_usage.c
+++ b/src/klog/ut/ut-klog_ring_buffer_usage.c
@@ -17,7 +17,7 @@ int no_async_param(
     KlogConsoleInfo console_info                = { KLOG_LEVEL_TRACE, false };
     klog_initialize(5, format_info, NULL, &console_info, NULL, NULL);
 
-    if (g_klog_state.message_element_idx != 0) {
+    if (g_klog_state.message_element_producer_idx != 0) {
         printf("Klog message element index should be 0 before anything is logged\n");
         return 1;
     }
@@ -76,7 +76,7 @@ int no_async_param(
     klog_logger_level_set(p, KLOG_LEVEL_INFO);
     klog_info(p, "test");
 
-    if (g_klog_state.message_element_idx != 0) {
+    if (g_klog_state.message_element_producer_idx != 0) {
         printf("Klog message element index should still be 0 because the buffer only has 1 element\n");
         return 1;
     }
@@ -119,7 +119,7 @@ int single_element(
     KlogConsoleInfo console_info         = { KLOG_LEVEL_INFO, false };
     klog_initialize(5, format_info, &async_info, &console_info, NULL, NULL);
 
-    if (g_klog_state.message_element_idx != 0) {
+    if (g_klog_state.message_element_producer_idx != 0) {
         printf("Klog message element index should be 0 before anything is logged\n");
         return 1;
     }
@@ -178,7 +178,7 @@ int single_element(
     klog_logger_level_set(p, KLOG_LEVEL_INFO);
     klog_info(p, "test");
 
-    if (g_klog_state.message_element_idx != 0) {
+    if (g_klog_state.message_element_producer_idx != 0) {
         printf("Klog message element index should still be 0 because the buffer only has 1 element\n");
         return 1;
     }
@@ -214,7 +214,7 @@ int multiple_elements(
 ) {
     const uint32_t  num_loggers          = 4;
     const uint32_t  logger_name_length   = 3;
-    const uint32_t  message_max_length   = 7; /* good length to set manually if needed */
+    const uint32_t  message_max_length   = 7;                      /* good length to set manually if needed */
     const uint32_t  message_total_length = message_max_length + 1; /* +1 because each is null terminated */
     const uint32_t  num_elements         = 3;
     KlogFormatInfo  format_info          = { logger_name_length, message_max_length, 0, false, false };
@@ -222,7 +222,7 @@ int multiple_elements(
     KlogConsoleInfo console_info         = { KLOG_LEVEL_DEBUG, false };
     klog_initialize(num_loggers, format_info, &async_info, &console_info, NULL, NULL);
 
-    if (g_klog_state.message_element_idx != 0) {
+    if (g_klog_state.message_element_producer_idx != 0) {
         printf("Klog message element index should be 0 before anything is logged\n");
         return 1;
     }
@@ -323,7 +323,7 @@ int multiple_elements(
     klog_logger_level_set(p, KLOG_LEVEL_INFO);
     klog_info(p, "1234567");
 
-    if (g_klog_state.message_element_idx != 1) {
+    if (g_klog_state.message_element_producer_idx != 1) {
         printf("Klog message element index should be 1 after the first log\n");
         return 1;
     }
@@ -393,7 +393,7 @@ int multiple_elements(
     klog_trace(p2, "this won't get logged due to the console's min level at debug, and no file logger");
     klog_debug(p2, "test number 2");
 
-    if (g_klog_state.message_element_idx != 2) {
+    if (g_klog_state.message_element_producer_idx != 2) {
         printf("Klog message element index should be 2 after the second log\n");
         return 1;
     }
@@ -441,7 +441,7 @@ int multiple_elements(
     klog_info(p3, "this won't get logged due to the logger's level");
     klog_error(p3, "test 3");
 
-    if (g_klog_state.message_element_idx != 0) {
+    if (g_klog_state.message_element_producer_idx != 0) {
         printf("Klog message element index should be 0 after the third log due to overflow\n");
         return 1;
     }
@@ -485,7 +485,7 @@ int multiple_elements(
 
     klog_info(p, "test, again!");
 
-    if (g_klog_state.message_element_idx != 1) {
+    if (g_klog_state.message_element_producer_idx != 1) {
         printf("Klog message element index should be 1 after the first log\n");
         return 1;
     }

--- a/src/klog/ut/ut-klog_ring_buffer_usage.c
+++ b/src/klog/ut/ut-klog_ring_buffer_usage.c
@@ -350,7 +350,7 @@ int multiple_elements(
         return 1;
     }
     klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
-    klog_platform_sleep_usec(100); /* Short sleep to allow async threads to log */
+    klog_platform_sleep_usec(1000); /* Short sleep to allow async threads to log */
     klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
     if (g_klog_state.message_element_consumer_idx != 1) {
         printf("Klog consumer message element index should be 1 after the first log\n");
@@ -432,7 +432,7 @@ int multiple_elements(
         return 1;
     }
     klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
-    klog_platform_sleep_usec(100); /* Short sleep to allow async threads to log */
+    klog_platform_sleep_usec(1000); /* Short sleep to allow async threads to log */
     klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
     if (g_klog_state.message_element_consumer_idx != 2) {
         printf("Klog consumer message element index should be 2 after the second log\n");

--- a/src/klog/ut/ut-klog_ring_buffer_usage.c
+++ b/src/klog/ut/ut-klog_ring_buffer_usage.c
@@ -6,6 +6,7 @@
 
 #include "../klog_state.h"
 #include "../klog_format.h"
+#include "../klog_platform.h"
 
 int no_async_param(
     void
@@ -223,7 +224,19 @@ int multiple_elements(
     klog_initialize(num_loggers, format_info, &async_info, &console_info, NULL, NULL);
 
     if (g_klog_state.message_element_producer_idx != 0) {
-        printf("Klog message element index should be 0 before anything is logged\n");
+        printf("Klog producer message element index should be 0 before anything is logged\n");
+        return 1;
+    }
+    if (g_klog_state.message_produced_total_count != 0) {
+        printf("Klog total produced message element count should be 0 before anything is logged\n");
+        return 1;
+    }
+    if (g_klog_state.message_element_consumer_idx != 0) {
+        printf("Klog consumer message element index should be 0 before anything is logged\n");
+        return 1;
+    }
+    if (g_klog_state.message_consumed_total_count != 0) {
+        printf("Klog total consumed message element count should be 0 before anything is logged\n");
         return 1;
     }
 
@@ -323,10 +336,27 @@ int multiple_elements(
     klog_logger_level_set(p, KLOG_LEVEL_INFO);
     klog_info(p, "1234567");
 
+    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
     if (g_klog_state.message_element_producer_idx != 1) {
-        printf("Klog message element index should be 1 after the first log\n");
+        printf("Klog producer message element index should be 1 after the first log\n");
         return 1;
     }
+    if (g_klog_state.message_produced_total_count != 1) {
+        printf("Klog total produced message element count should be 1 after the first log\n");
+        return 1;
+    }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
+    klog_platform_sleep_usec(100); /* Short sleep to allow async threads to log */
+    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
+    if (g_klog_state.message_element_consumer_idx != 1) {
+        printf("Klog consumer message element index should be 1 after the first log\n");
+        return 1;
+    }
+    if (g_klog_state.message_consumed_total_count != 1) {
+        printf("Klog total consumed message element count should be 1 after the first log\n");
+        return 1;
+    }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
 
     char* full_prefix_buffer = "[dum] [info ] ";
     if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer, prefix_size)) {
@@ -384,10 +414,27 @@ int multiple_elements(
     klog_trace(p2, "this won't get logged due to the console's min level at debug, and no file logger");
     klog_debug(p2, "test number 2");
 
+    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
     if (g_klog_state.message_element_producer_idx != 2) {
         printf("Klog message element index should be 2 after the second log\n");
         return 1;
     }
+    if (g_klog_state.message_produced_total_count != 2) {
+        printf("Klog total produced message element count should be 2 after the second log\n");
+        return 1;
+    }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
+    klog_platform_sleep_usec(100); /* Short sleep to allow async threads to log */
+    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
+    if (g_klog_state.message_element_consumer_idx != 2) {
+        printf("Klog consumer message element index should be 2 after the second log\n");
+        return 1;
+    }
+    if (g_klog_state.message_consumed_total_count != 2) {
+        printf("Klog total consumed message element count should be 2 after the second log\n");
+        return 1;
+    }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
 
     char* full_prefix_buffer_2 = "[two] [debug] ";
     if (memcmp(g_klog_state.b_prefixes_file + prefix_size, full_prefix_buffer_2, prefix_size)) {
@@ -423,10 +470,27 @@ int multiple_elements(
     klog_info(p3, "this won't get logged due to the logger's level");
     klog_error(p3, "test 3");
 
+    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
     if (g_klog_state.message_element_producer_idx != 0) {
         printf("Klog message element index should be 0 after the third log due to overflow\n");
         return 1;
     }
+    if (g_klog_state.message_produced_total_count != 3) {
+        printf("Klog total produced message element count should be 3 after the third log\n");
+        return 1;
+    }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
+    klog_platform_sleep_usec(1000); /* Short sleep to allow async threads to log */
+    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
+    if (g_klog_state.message_element_consumer_idx != 0) {
+        printf("Klog consumer message element index should be 0 after the third log due to overflow\n");
+        return 1;
+    }
+    if (g_klog_state.message_consumed_total_count != 3) {
+        printf("Klog total consumed message element count should be 3 after the third log\n");
+        return 1;
+    }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
 
     char* full_prefix_buffer_3 = "[3  ] [ERROR] ";
     if (memcmp(g_klog_state.b_prefixes_file + prefix_size * 2, full_prefix_buffer_3, prefix_size)) {
@@ -467,10 +531,27 @@ int multiple_elements(
 
     klog_info(p, "test, again!");
 
+    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
     if (g_klog_state.message_element_producer_idx != 1) {
-        printf("Klog message element index should be 1 after the first log\n");
+        printf("Klog message element index should be 1 after the fourth log due to overflow\n");
         return 1;
     }
+    if (g_klog_state.message_produced_total_count != 4) {
+        printf("Klog total produced message element count should be 4 after the fourth log\n");
+        return 1;
+    }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
+    klog_platform_sleep_usec(1000); /* Short sleep to allow async threads to log */
+    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
+    if (g_klog_state.message_element_consumer_idx != 1) {
+        printf("Klog consumer message element index should be 1 after the fourth log due to overflow\n");
+        return 1;
+    }
+    if (g_klog_state.message_consumed_total_count != 4) {
+        printf("Klog total consumed message element count should be 4 after the fourth log\n");
+        return 1;
+    }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
 
     if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer, prefix_size)) {
         printf(


### PR DESCRIPTION
# v0.0.17 - Async logging threads

<!--
Include updated version, and use imperative mood.
Ex:

v1.2.3 rename boop to beep
-->

---

## Description

<!--
What does this change do?

- Describe the previous behavior and why it was bad.
- Describe the updated behavior and why it is good.
-->

This change enables the usage of dedicated threads for logging messages, so the user's main (calling) thread doesn't block for IO.

### Implementation Details

<!--
What changes were made in order to get the desired, updated behavior?

- Give details that will help reviewers understand what is going on.
-->

This introduces many changes. The most notable changes involve a refactor of the primary logging function, via splitting up the function into two steps (a producing step and a consuming step) so we can reuse the second step in a dedicated logging thread.

There are other small changes wrapped up in this PR as well, such as updating the logic for initializing the log file to save the filename in the global state allowing us to reference it in unit tests.

---

## Motivation

<!--
Why is this change needed?

- What problem does it solve?
- Why is this the correct fix? Why not alternative approaches?
-->

This change is necessary for future performance improvements.

### Related Issues

<!--
Which issues does this close? Ex:

- closes #1
- closes #42
-->

There are no related issues on github at the time of creating this PR.

---

## Testing

<!--
How was this validated?

- Were new tests added? If so, which ones?
- Which currently in place tests are relevant?
- Include logs, traces, or minimal repro steps if applicable.
-->

- 2 new functional tests were added validating the logging capabilities do not enter deadlock when run with async threads
- many of the unit tests were updated to consider async capabilities
- a new unit test was added to ensure the async threads don't end up logging messages out of order

---

## Checklist

- [x] Adherance to style guide (naming and formatting)
- [x] All tests pass
- [x] New tests added where appropriate
- [x] Documentation updated (everything exposed in headers really)
- [x] Concurrency implications considered
- [x] Self review performed
- [x] Version incremented if appropriate

---
