### PR TITLE
v0.0.18 Async Performance Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ scratch/
 compile_commands.json
 
 notes.md
+
+.vscode

--- a/cmake/KlogVersion.cmake
+++ b/cmake/KlogVersion.cmake
@@ -21,4 +21,5 @@ endfunction()
 # set_klog_versions(0 0 14) # Pre-allocate multiple formatted input message buffer to prep for multi-threading support
 # set_klog_versions(0 0 15) # Don't allocate when formatting logger names
 # set_klog_versions(0 0 16) # Examples!
-set_klog_versions(0 0 17) # Async logging with dedicated threads
+# set_klog_versions(0 0 17) # Async logging with dedicated threads
+set_klog_versions(0 0 18) # Async logging improvements

--- a/include/klog/klog.h
+++ b/include/klog/klog.h
@@ -31,7 +31,7 @@ typedef struct {
 
 typedef struct {
     uint32_t message_queue_number_elements;
-    uint32_t number_backing_threads;
+    uint32_t number_backing_threads; /* If this is gt 1, ordering of messages is not enforced */
 } KlogAsyncInfo;
 
 typedef struct {

--- a/include/klog/klog.h
+++ b/include/klog/klog.h
@@ -29,9 +29,13 @@ typedef struct {
     bool     use_timestamp;
 } KlogFormatInfo;
 
+/**
+ * If number_backing_threads is greater than 1, the ordering of the output messages is not
+ * guaranteed to be the same as the order of the inputs
+ */
 typedef struct {
     uint32_t message_queue_number_elements;
-    uint32_t number_backing_threads; /* If this is gt 1, ordering of messages is not enforced */
+    uint32_t number_backing_threads;
 } KlogAsyncInfo;
 
 typedef struct {

--- a/scripts/iterate_until_failure.sh
+++ b/scripts/iterate_until_failure.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]; then
+    echo "You must provide an executable (and optionally its arguments) to run via command line arguments"
+    exit 1
+fi
+
+while true; do
+    clear
+
+    echo "Executing: $@"
+
+    "$@"
+
+    if [ $? -ne 0 ]; then
+        break
+    fi
+done

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -16,6 +16,21 @@ BGYELLOW=$(tput setab 3)
 BGMAGENTA=$(tput setab 5)
 NORMAL=$(tput sgr0) # Resets all attributes
 
+# Error / success messages
+# These look bad when declared here but they are all aligned for nicely printing
+P_EF="${FGRED}PASSED      (should fail)${NORMAL}"
+ME_EF="${FGYELLOW}MEMERR      (should fail)${NORMAL}"
+F_EF="${NORMAL}failed      (should fail)${NORMAL}"
+P_EP="${NORMAL}passed      (should pass)${NORMAL}"
+ME_EP="${FGYELLOW}MEMERR      (should pass)${NORMAL}"
+F_EP="${FGRED}FAILED      (should pass)${NORMAL}"
+
+# -------------------------------------------------------------------------------------------------------------------- #
+# Where we actually store the results (initialize an empty list)                                                       #
+# -------------------------------------------------------------------------------------------------------------------- #
+
+failed_commands=()
+
 # -------------------------------------------------------------------------------------------------------------------- #
 # Determine which tests should fail, and for which tests we should ignore the valgrind information                     #
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -35,50 +50,39 @@ if [ -f "$ignore_memory_list_file" ]; then
 fi
 
 # -------------------------------------------------------------------------------------------------------------------- #
-# Determine which tests to run, and run them all, making note of which ones failed and in what fashion                 #
+# Helper function to actually run the test and check the error result                                                  #
 # -------------------------------------------------------------------------------------------------------------------- #
 
-# Create list of all tests from the ft and ut directories
-uts_to_run=(./bin/ut/*)
-fts_to_run=(./bin/ft/*)
-all_tests_to_run=("${uts_to_run[@]}" "${fts_to_run[@]}")
+run_test_update_failed_commands () {
+    local arg_test_command="$1"
+    local arg_command_to_run="$2"
+    local arg_is_valgrind="$3"
 
-# These look bad when declared here but they are all aligned for nicely printing
-P_EF="${FGRED}PASSED (should fail)${NORMAL}"
-ME_EF="${FGYELLOW}MEMERR (should fail)${NORMAL}"
-F_EF="failed (should fail)${NORMAL}"
-P_EP="passed (should pass)${NORMAL}"
-ME_EP="${FGYELLOW}MEMERR (should pass)${NORMAL}"
-F_EP="${FGRED}FAILED (should pass)${NORMAL}"
+    local arg_test_name=$(basename "$arg_test_command")
 
-exit_code=0
-
-# Do the thing (execute all tests, and take note of failed commands)
-failed_commands=()
-for test_command in "${all_tests_to_run[@]}"; do
-    test_name=$(basename "$test_command")
-
-    if [[ "$test_name" == "*" ]]; then
-        continue
-    fi
-
-    command_to_run="$test_command"
-
-    if [[ ! " ${ignore_memory_list[*]} " =~ " ${test_name} " ]]; then
-        command_to_run="valgrind --tool=memcheck --enable-debuginfod=no --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=all --error-exitcode=54 $command_to_run"
+    # Align this output with our error/pass result outputs
+    if [ "$arg_is_valgrind" -eq 0 ]; then
+        #    "passed      (should pass) : "
+        echo "executing                 : $arg_test_name"
+    else
+        #    "passed      (should pass) : "
+        echo "valgrinding               : $arg_test_name"
     fi
 
     $command_to_run > /dev/null 2>&1
-    status=$?
+    local status=$?
 
-    result_message="PASSED"
-    if [[ " ${expected_failure_list[*]} " =~ " ${test_name} " ]]; then # If we should have failed
+    local did_expected=1
+    local result_message="PLACEHOLDER_RESULT"
+    if [[ " ${expected_failure_list[*]} " =~ " ${arg_test_name} " ]]; then # If we should have failed
         if [ "$status" -eq 0 ]; then
             result_message=$P_EF
             failed_commands+=( "$command_to_run" )
+            did_expected=0
         elif [ "$status" -eq 54 ]; then
             result_message=$ME_EF
             failed_commands+=( "$command_to_run" )
+            did_expected=0
         else
             result_message=$F_EF
         fi
@@ -88,13 +92,63 @@ for test_command in "${all_tests_to_run[@]}"; do
         elif [ "$status" -eq 54 ]; then
             result_message=$ME_EP
             failed_commands+=( "$command_to_run" )
+            did_expected=0
         else
             result_message=$F_EP
             failed_commands+=( "$command_to_run" )
+            did_expected=0
         fi
     fi
+    
+    echo "$result_message : $arg_test_name"
 
-    echo "$result_message : $test_name"
+    if [ "$did_expected" -eq 1 ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# -------------------------------------------------------------------------------------------------------------------- #
+# Determine which tests to run, and run them all, making note of which ones failed and in what fashion                 #
+# -------------------------------------------------------------------------------------------------------------------- #
+
+# Create list of all tests from the ft and ut directories
+uts_to_run=(./bin/ut/*)
+fts_to_run=(./bin/ft/*)
+all_tests_to_run=("${uts_to_run[@]}" "${fts_to_run[@]}")
+
+# Do the thing (execute all tests, and take note of failed commands)
+for test_command in "${all_tests_to_run[@]}"; do
+    test_name=$(basename "$test_command")
+
+    if [[ "$test_name" == "*" ]]; then
+        continue
+    fi
+
+    # ------------------------------------------------------------------------------------------------------ #
+    # First pass: run the test without valgrind to ensure the logic is valid                                 #
+    # ------------------------------------------------------------------------------------------------------ #
+    
+    command_to_run="$test_command"
+
+    run_test_update_failed_commands "$test_command" "$command_to_run" 0
+
+    passed=$?
+
+    if [ $passed -eq 1 ]; then
+        continue
+    fi
+
+    # ------------------------------------------------------------------------------------------------------ #
+    # Second pass: run the test with valgrind to ensure the memory usage is valid                            #
+    # ------------------------------------------------------------------------------------------------------ #
+
+    if [[ ! " ${ignore_memory_list[*]} " =~ " ${test_name} " ]]; then
+        command_to_run="valgrind --tool=memcheck --enable-debuginfod=no --leak-check=full --show-leak-kinds=all --errors-for-leak-kinds=all --error-exitcode=54 $command_to_run"
+
+        run_test_update_failed_commands "$test_command" "$command_to_run" 1
+    fi
 done
 
 echo ""

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -16,7 +16,26 @@ BGYELLOW=$(tput setab 3)
 BGMAGENTA=$(tput setab 5)
 NORMAL=$(tput sgr0) # Resets all attributes
 
-# Error / success messages
+# -------------------------------------------------------------------------------------------------------------------- #
+# Get CL argument for whether or not we should pre-document the executable we are about to run                         #
+# -------------------------------------------------------------------------------------------------------------------- #
+
+should_pre_print=0
+while getopts "v" opt; do
+    case ${opt} in
+        v)
+            should_pre_print=1
+            ;;
+        \?)
+            exit 1
+            ;;
+    esac
+done
+
+# -------------------------------------------------------------------------------------------------------------------- #
+# Error and success messages, need the pre print flag for spacing                                                      #
+# -------------------------------------------------------------------------------------------------------------------- #
+
 # These look bad when declared here but they are all aligned for nicely printing
 P_EF="${FGRED}PASSED      (should fail)${NORMAL}"
 ME_EF="${FGYELLOW}MEMERR      (should fail)${NORMAL}"
@@ -24,6 +43,15 @@ F_EF="${NORMAL}failed      (should fail)${NORMAL}"
 P_EP="${NORMAL}passed      (should pass)${NORMAL}"
 ME_EP="${FGYELLOW}MEMERR      (should pass)${NORMAL}"
 F_EP="${FGRED}FAILED      (should pass)${NORMAL}"
+
+if [ $should_pre_print -eq 0 ]; then
+    P_EF="${FGRED}PASSED (should fail)${NORMAL}"
+    ME_EF="${FGYELLOW}MEMERR (should fail)${NORMAL}"
+    F_EF="${NORMAL}failed (should fail)${NORMAL}"
+    P_EP="${NORMAL}passed (should pass)${NORMAL}"
+    ME_EP="${FGYELLOW}MEMERR (should pass)${NORMAL}"
+    F_EP="${FGRED}FAILED (should pass)${NORMAL}"
+fi
 
 # -------------------------------------------------------------------------------------------------------------------- #
 # Where we actually store the results (initialize an empty list)                                                       #
@@ -61,12 +89,14 @@ run_test_update_failed_commands () {
     local arg_test_name=$(basename "$arg_test_command")
 
     # Align this output with our error/pass result outputs
-    if [ "$arg_is_valgrind" -eq 0 ]; then
-        #    "passed      (should pass) : "
-        echo "executing                 : $arg_test_name"
-    else
-        #    "passed      (should pass) : "
-        echo "valgrinding               : $arg_test_name"
+    if [ $should_pre_print -eq 1 ]; then
+      if [ "$arg_is_valgrind" -eq 0 ]; then
+          #    "passed      (should pass) : "
+          echo "executing                 : $arg_test_name"
+      else
+          #    "passed      (should pass) : "
+          echo "valgrinding               : $arg_test_name"
+      fi
     fi
 
     $command_to_run > /dev/null 2>&1
@@ -99,8 +129,12 @@ run_test_update_failed_commands () {
             did_expected=0
         fi
     fi
-    
-    echo "$result_message : $arg_test_name"
+   
+    if [ "$arg_is_valgrind" -eq 0 ]; then
+        echo "$result_message : $arg_test_name"
+    else
+        echo "$result_message : $arg_test_name - valgrind"
+    fi
 
     if [ "$did_expected" -eq 1 ]; then
         return 0

--- a/src/klog/ft/ft-klog_async_1_thread.c
+++ b/src/klog/ft/ft-klog_async_1_thread.c
@@ -6,7 +6,7 @@
 
 #include "../klog_debug_util.h"
 
-#define NUM_LOG_STATEMENTS 20
+#define NUM_LOG_STATEMENTS 30
 
 int main(
     void

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -516,7 +516,6 @@ void klog_log(
     klog_platform_semaphore_wait(g_klog_state.p_semaphore_messages_empty);
 
     klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
-    /* Let everyone know there is another message ready for consumption */
     g_klog_state.message_produced_total_count++;
     g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count + 1;
     if (g_klog_state.message_unconsumed_count > g_klog_state.message_element_count) {

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -513,10 +513,37 @@ void klog_log(
         return;
     }
 
+    klog_platform_semaphore_wait(g_klog_state.p_semaphore_messages_empty);
+
+    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
+    /* Let everyone know there is another message ready for consumption */
+    g_klog_state.message_produced_total_count++;
+    g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count + 1;
+    if (g_klog_state.message_unconsumed_count > g_klog_state.message_element_count) {
+        kdprintf(
+            "klog_log produced too many messages (%d unconsumed messages when we only have space for %d)\n",
+            g_klog_state.message_unconsumed_count,
+            g_klog_state.message_element_count
+        );
+        exit(1);
+    }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
+
+    klog_platform_mutex_lock(g_klog_state.p_mutex_producer);
+    /* Update the producer's index into our ring buffer */
+    const uint32_t message_element_producer_idx = g_klog_state.message_element_producer_idx;
+    g_klog_state.message_element_producer_idx   = g_klog_state.message_element_producer_idx + 1;
+    if (g_klog_state.message_element_producer_idx >= g_klog_state.message_element_count) {
+        g_klog_state.message_element_producer_idx = 0;
+    }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_producer);
+
+    /* @todo LOCK TIME BUFFER DOWN */
     /* We are getting the time first, so it's closest to the actual point of invocation */
-    char* s_prefix_time = g_klog_state.b_prefixes_time + (g_klog_state.message_element_producer_idx * g_klog_state.prefix_time_size);
+    char* s_prefix_time = g_klog_state.b_prefixes_time + (message_element_producer_idx * g_klog_state.prefix_time_size);
     memset(s_prefix_time, '\0', g_klog_state.prefix_time_size);
     const KlogString packed_time = g_klog_config.format.use_timestamp ? klog_format_time(s_prefix_time) : (KlogString) { 0, NULL };
+    /* @todo UNLOCK TIME BUFFER */
 
     /* Get the information to create the message prefixes */
     const uint32_t    thread_id         = (uint32_t)klog_platform_get_current_thread_id();
@@ -532,9 +559,10 @@ void klog_log(
     const KlogString        packed_level_file      = { G_klog_level_string_length, s_level };
     const KlogString* const p_packed_level_console = g_klog_config.console.use_color ? &packed_level_color : &packed_level_file;
 
+    /* @todo LOCK SOURCE LOCATION BUFFER DOWN */
     /* Source location for the message prefix */
     char* s_prefix_source_location = g_klog_state.b_prefixes_source_location
-        + (g_klog_state.message_element_producer_idx * g_klog_state.prefix_source_location_size);
+        + (message_element_producer_idx * g_klog_state.prefix_source_location_size);
     const KlogString packed_source_location = (g_klog_config.format.source_location_filename_max_length && s_filename)
         ? klog_format_source_location(
                 s_prefix_source_location,
@@ -543,18 +571,17 @@ void klog_log(
                 line_number
             )
         : (KlogString) { 0, NULL };
-
-    klog_platform_semaphore_wait(g_klog_state.p_semaphore_messages_empty);
+    /* @todo UNLOCK SOURCE LOCATION */
 
     klog_platform_mutex_lock(g_klog_state.p_mutex_message_levels);
     /* Update the level buffer */
-    g_klog_state.b_message_levels[g_klog_state.message_element_producer_idx] = requested_level;
+    g_klog_state.b_message_levels[message_element_producer_idx] = requested_level;
     klog_platform_mutex_unlock(g_klog_state.p_mutex_message_levels);
 
     klog_platform_mutex_lock(g_klog_state.p_mutex_messages_formatted);
     /* Create the input string with the arguments injected - including space for null termination */
     char* s_message_formatted = g_klog_state.b_messages_formatted
-        + (g_klog_state.message_element_producer_idx * g_klog_state.message_formatted_max_size);
+        + (message_element_producer_idx * g_klog_state.message_formatted_max_size);
     /* Clear the message buffer for the formatted message we just used */
     memset(s_message_formatted, 0, g_klog_state.message_formatted_max_size);
     va_list p_args;
@@ -570,13 +597,13 @@ void klog_log(
 
     klog_platform_mutex_lock(g_klog_state.p_mutex_message_lengths);
     /* Update the length buffer */
-    g_klog_state.b_message_lengths[g_klog_state.message_element_producer_idx] = actual_message_length;
+    g_klog_state.b_message_lengths[message_element_producer_idx] = actual_message_length;
     klog_platform_mutex_unlock(g_klog_state.p_mutex_message_lengths);
 
     klog_platform_mutex_lock(g_klog_state.p_mutex_prefixes_file);
     /* Actually create the file prefix */
     char* s_prefix_file = g_klog_state.b_prefixes_file
-        + (g_klog_state.message_element_producer_idx * (g_klog_state.prefix_file_size + 1));
+        + (message_element_producer_idx * (g_klog_state.prefix_file_size + 1));
     memset(s_prefix_file, '\0', g_klog_state.prefix_file_size);
     const KlogString packed_prefix_file = klog_format_message_prefix(
         s_prefix_file,
@@ -591,7 +618,7 @@ void klog_log(
     klog_platform_mutex_lock(g_klog_state.p_mutex_prefixes_console);
     /* Actually create the console prefix */
     char* s_prefix_console = g_klog_state.b_prefixes_console
-        + (g_klog_state.message_element_producer_idx * (g_klog_state.prefix_console_size + 1));
+        + (message_element_producer_idx * (g_klog_state.prefix_console_size + 1));
     memset(s_prefix_console, '\0', g_klog_state.prefix_console_size);
     const KlogString packed_prefix_console = klog_format_message_prefix(
         s_prefix_console,
@@ -603,33 +630,8 @@ void klog_log(
     );
     klog_platform_mutex_unlock(g_klog_state.p_mutex_prefixes_console);
 
-    klog_platform_mutex_lock(g_klog_state.p_mutex_producer);
-    /* @todo This can move outside the shared block into a producer specific lock */
-    /* Update the producer's index into our ring buffer */
-    g_klog_state.message_element_producer_idx = g_klog_state.message_element_producer_idx + 1;
-    if (g_klog_state.message_element_producer_idx >= g_klog_state.message_element_count) {
-        g_klog_state.message_element_producer_idx = 0;
-    }
-    klog_platform_mutex_unlock(g_klog_state.p_mutex_producer);
-
-    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
-    /* @todo Move these variable accesses behind a "stop" lock? */
-    /* Let everyone know there is another message ready for consumption */
-    g_klog_state.message_produced_total_count++;
-    g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count + 1;
-    if (g_klog_state.message_unconsumed_count > g_klog_state.message_element_count) {
-        kdprintf(
-            "klog_log produced too many messages (%d unconsumed messages when we only have space for %d)\n",
-            g_klog_state.message_unconsumed_count,
-            g_klog_state.message_element_count
-        );
-        exit(1);
-    }
-    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
-
     klog_platform_semaphore_signal(g_klog_state.p_semaphore_messages_full);
 
-    (void)actual_message_length;
     (void)packed_prefix_file;
     (void)packed_prefix_console;
 

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -457,8 +457,6 @@ void klog_log(
     (void)line_number;
     (void)format;
 #else
-    /* klog_platform_mutex_lock(g_klog_state.p_mutex_producer); */
-
     klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
     if (!g_klog_state.is_initialized) {
         kdprintf("Trying to create klog logger, but klog is not initialized\n");
@@ -478,18 +476,15 @@ void klog_log(
 
     if (requested_level == 0) {
         kdprintf("Trying to log with the level set to OFF\n");
-        /* klog_platform_mutex_unlock(g_klog_state.p_mutex_producer); */
         return;
     }
     if ((requested_level > g_klog_config.console.max_level) && (requested_level > g_klog_config.file.max_level)) {
         kdprintf("Trying to log with a level that neither console nor file accept\n");
-        /* klog_platform_mutex_unlock(g_klog_state.p_mutex_producer); */
         return;
     }
 
     if (requested_level > g_klog_state.a_logger_levels[p_logger_handle->value]) {
         kdprintf("Trying to log with a level more verbose than the requested logger allows\n");
-        /* klog_platform_mutex_unlock(g_klog_state.p_mutex_producer); */
         return;
     }
 
@@ -593,8 +588,6 @@ void klog_log(
     klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
 
     klog_platform_semaphore_signal(g_klog_state.p_semaphore_messages_full);
-
-    /* klog_platform_mutex_unlock(g_klog_state.p_mutex_producer); */
 
     (void)actual_message_length;
     (void)packed_prefix_file;

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -220,13 +220,23 @@ void klog_initialize(
     g_klog_state.s_filename = klog_format_filename(p_klog_file_info, g_klog_config.alloc.alloc_cb, g_klog_config.alloc.free_cb);
     g_klog_state.p_file     = klog_initialize_file(g_klog_state.s_filename);
 
-    g_klog_state.p_mutex_deinitialize   = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_shared         = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_producer       = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_consumer       = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_output_console = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_output_file    = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_deinitialize       = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_message_levels     = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_messages_formatted = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_message_lengths    = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_prefixes_file      = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_prefixes_console   = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_shared             = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_producer           = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_consumer           = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_output_console     = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_output_file        = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
     klog_platform_mutex_initialize(g_klog_state.p_mutex_deinitialize);
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_message_levels);
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_messages_formatted);
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_message_lengths);
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_prefixes_file);
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_prefixes_console);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_shared);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_producer);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_consumer);
@@ -273,24 +283,39 @@ void klog_deinitialize(
         g_klog_config.alloc.free_cb(g_klog_state.b_threads);
     }
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_deinitialize);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_message_levels);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_messages_formatted);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_message_lengths);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_prefixes_file);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_prefixes_console);
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_shared);
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_producer);
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_consumer);
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_output_console);
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_output_file);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_deinitialize);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_message_levels);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_messages_formatted);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_message_lengths);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_prefixes_file);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_prefixes_console);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_shared);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_producer);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_consumer);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_output_console);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_output_file);
-    g_klog_state.b_threads              = NULL;
-    g_klog_state.p_mutex_deinitialize   = NULL;
-    g_klog_state.p_mutex_shared         = NULL;
-    g_klog_state.p_mutex_producer       = NULL;
-    g_klog_state.p_mutex_consumer       = NULL;
-    g_klog_state.p_mutex_output_console = NULL;
-    g_klog_state.p_mutex_output_file    = NULL;
+    g_klog_state.b_threads                  = NULL;
+    g_klog_state.p_mutex_deinitialize       = NULL;
+    g_klog_state.p_mutex_message_levels     = NULL;
+    g_klog_state.p_mutex_messages_formatted = NULL;
+    g_klog_state.p_mutex_message_lengths    = NULL;
+    g_klog_state.p_mutex_prefixes_file      = NULL;
+    g_klog_state.p_mutex_prefixes_console   = NULL;
+    g_klog_state.p_mutex_shared             = NULL;
+    g_klog_state.p_mutex_producer           = NULL;
+    g_klog_state.p_mutex_consumer           = NULL;
+    g_klog_state.p_mutex_output_console     = NULL;
+    g_klog_state.p_mutex_output_file        = NULL;
 
     klog_platform_semaphore_deinitialize(g_klog_state.p_semaphore_messages_empty);
     klog_platform_semaphore_deinitialize(g_klog_state.p_semaphore_messages_full);
@@ -521,11 +546,12 @@ void klog_log(
 
     klog_platform_semaphore_wait(g_klog_state.p_semaphore_messages_empty);
 
-    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
-
+    klog_platform_mutex_lock(g_klog_state.p_mutex_message_levels);
     /* Update the level buffer */
     g_klog_state.b_message_levels[g_klog_state.message_element_producer_idx] = requested_level;
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_message_levels);
 
+    klog_platform_mutex_lock(g_klog_state.p_mutex_messages_formatted);
     /* Create the input string with the arguments injected - including space for null termination */
     char* s_message_formatted = g_klog_state.b_messages_formatted
         + (g_klog_state.message_element_producer_idx * g_klog_state.message_formatted_max_size);
@@ -540,10 +566,14 @@ void klog_log(
         p_args
     );
     va_end(p_args);
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_messages_formatted);
 
+    klog_platform_mutex_lock(g_klog_state.p_mutex_message_lengths);
     /* Update the length buffer */
     g_klog_state.b_message_lengths[g_klog_state.message_element_producer_idx] = actual_message_length;
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_message_lengths);
 
+    klog_platform_mutex_lock(g_klog_state.p_mutex_prefixes_file);
     /* Actually create the file prefix */
     char* s_prefix_file = g_klog_state.b_prefixes_file
         + (g_klog_state.message_element_producer_idx * (g_klog_state.prefix_file_size + 1));
@@ -556,7 +586,9 @@ void klog_log(
         &packed_level_file,
         &packed_source_location
     );
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_prefixes_file);
 
+    klog_platform_mutex_lock(g_klog_state.p_mutex_prefixes_console);
     /* Actually create the console prefix */
     char* s_prefix_console = g_klog_state.b_prefixes_console
         + (g_klog_state.message_element_producer_idx * (g_klog_state.prefix_console_size + 1));
@@ -569,14 +601,18 @@ void klog_log(
         p_packed_level_console,
         &packed_source_location
     );
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_prefixes_console);
 
+    klog_platform_mutex_lock(g_klog_state.p_mutex_producer);
     /* @todo This can move outside the shared block into a producer specific lock */
     /* Update the producer's index into our ring buffer */
     g_klog_state.message_element_producer_idx = g_klog_state.message_element_producer_idx + 1;
     if (g_klog_state.message_element_producer_idx >= g_klog_state.message_element_count) {
         g_klog_state.message_element_producer_idx = 0;
     }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_producer);
 
+    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
     /* @todo Move these variable accesses behind a "stop" lock? */
     /* Let everyone know there is another message ready for consumption */
     g_klog_state.message_produced_total_count++;
@@ -589,7 +625,6 @@ void klog_log(
         );
         exit(1);
     }
-
     klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
 
     klog_platform_semaphore_signal(g_klog_state.p_semaphore_messages_full);

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -538,12 +538,15 @@ void klog_log(
     }
     klog_platform_mutex_unlock(g_klog_state.p_mutex_producer);
 
-    /* @todo LOCK TIME BUFFER DOWN */
+    /**
+     * @brief We don't need to put a lock around the b_prefixes_time here, because it is gauranteed that only one
+     *      producer can be here with this specific message_element_producer_idx at a time. So no two producers can possibly
+     *      be modifying the same part of this buffer, and the consumer doesn't look in here, so we are safe.
+     */
     /* We are getting the time first, so it's closest to the actual point of invocation */
     char* s_prefix_time = g_klog_state.b_prefixes_time + (message_element_producer_idx * g_klog_state.prefix_time_size);
     memset(s_prefix_time, '\0', g_klog_state.prefix_time_size);
     const KlogString packed_time = g_klog_config.format.use_timestamp ? klog_format_time(s_prefix_time) : (KlogString) { 0, NULL };
-    /* @todo UNLOCK TIME BUFFER */
 
     /* Get the information to create the message prefixes */
     const uint32_t    thread_id         = (uint32_t)klog_platform_get_current_thread_id();
@@ -559,7 +562,11 @@ void klog_log(
     const KlogString        packed_level_file      = { G_klog_level_string_length, s_level };
     const KlogString* const p_packed_level_console = g_klog_config.console.use_color ? &packed_level_color : &packed_level_file;
 
-    /* @todo LOCK SOURCE LOCATION BUFFER DOWN */
+    /**
+     * @brief We don't need to put a lock around the b_prefixes_source_location here, because it is gauranteed that only one
+     *      producer can be here with this specific message_element_producer_idx at a time. So no two producers can possibly
+     *      be modifying the same part of this buffer, and the consumer doesn't look in here, so we are safe.
+     */
     /* Source location for the message prefix */
     char* s_prefix_source_location = g_klog_state.b_prefixes_source_location
         + (message_element_producer_idx * g_klog_state.prefix_source_location_size);
@@ -571,7 +578,6 @@ void klog_log(
                 line_number
             )
         : (KlogString) { 0, NULL };
-    /* @todo UNLOCK SOURCE LOCATION */
 
     klog_platform_mutex_lock(g_klog_state.p_mutex_message_levels);
     /* Update the level buffer */

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -457,7 +457,7 @@ void klog_log(
     (void)line_number;
     (void)format;
 #else
-    klog_platform_mutex_lock(g_klog_state.p_mutex_producer);
+    /* klog_platform_mutex_lock(g_klog_state.p_mutex_producer); */
 
     klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
     if (!g_klog_state.is_initialized) {
@@ -478,18 +478,18 @@ void klog_log(
 
     if (requested_level == 0) {
         kdprintf("Trying to log with the level set to OFF\n");
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_producer);
+        /* klog_platform_mutex_unlock(g_klog_state.p_mutex_producer); */
         return;
     }
     if ((requested_level > g_klog_config.console.max_level) && (requested_level > g_klog_config.file.max_level)) {
         kdprintf("Trying to log with a level that neither console nor file accept\n");
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_producer);
+        /* klog_platform_mutex_unlock(g_klog_state.p_mutex_producer); */
         return;
     }
 
     if (requested_level > g_klog_state.a_logger_levels[p_logger_handle->value]) {
         kdprintf("Trying to log with a level more verbose than the requested logger allows\n");
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_producer);
+        /* klog_platform_mutex_unlock(g_klog_state.p_mutex_producer); */
         return;
     }
 
@@ -594,7 +594,7 @@ void klog_log(
 
     klog_platform_semaphore_signal(g_klog_state.p_semaphore_messages_full);
 
-    klog_platform_mutex_unlock(g_klog_state.p_mutex_producer);
+    /* klog_platform_mutex_unlock(g_klog_state.p_mutex_producer); */
 
     (void)actual_message_length;
     (void)packed_prefix_file;

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -570,12 +570,14 @@ void klog_log(
         &packed_source_location
     );
 
+    /* @todo This can move outside the shared block into a producer specific lock */
     /* Update the producer's index into our ring buffer */
     g_klog_state.message_element_producer_idx = g_klog_state.message_element_producer_idx + 1;
     if (g_klog_state.message_element_producer_idx >= g_klog_state.message_element_count) {
         g_klog_state.message_element_producer_idx = 0;
     }
 
+    /* @todo Move these variable accesses behind a "stop" lock? */
     /* Let everyone know there is another message ready for consumption */
     g_klog_state.message_produced_total_count++;
     g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count + 1;

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -199,29 +199,15 @@ void klog_initialize(
         sizeof(*g_klog_state.b_message_lengths)
         * g_klog_state.message_element_count
     );
-    g_klog_state.b_message_lengths_staging = g_klog_config.alloc.alloc_cb(
-        sizeof(*g_klog_state.b_message_lengths_staging)
-        * g_klog_state.message_element_count
-    );
     memset(
         g_klog_state.b_message_lengths,
         0,
         sizeof(*g_klog_state.b_message_lengths)
         * g_klog_state.message_element_count
     );
-    memset(
-        g_klog_state.b_message_lengths_staging,
-        0,
-        sizeof(*g_klog_state.b_message_lengths_staging)
-        * g_klog_state.message_element_count
-    );
 
     g_klog_state.b_message_levels = g_klog_config.alloc.alloc_cb(
         sizeof(*g_klog_state.b_message_levels)
-        * g_klog_state.message_element_count
-    );
-    g_klog_state.b_message_levels_staging = g_klog_config.alloc.alloc_cb(
-        sizeof(*g_klog_state.b_message_levels_staging)
         * g_klog_state.message_element_count
     );
     memset(
@@ -230,24 +216,22 @@ void klog_initialize(
         sizeof(*g_klog_state.b_message_levels)
         * g_klog_state.message_element_count
     );
-    memset(
-        g_klog_state.b_message_levels_staging,
-        0,
-        sizeof(*g_klog_state.b_message_levels_staging)
-        * g_klog_state.message_element_count
-    );
 
     g_klog_state.s_filename = klog_format_filename(p_klog_file_info, g_klog_config.alloc.alloc_cb, g_klog_config.alloc.free_cb);
     g_klog_state.p_file     = klog_initialize_file(g_klog_state.s_filename);
 
-    g_klog_state.p_mutex_deinitialize = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_shared       = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_producer     = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_consumer     = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_deinitialize   = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_shared         = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_producer       = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_consumer       = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_output_console = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_output_file    = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
     klog_platform_mutex_initialize(g_klog_state.p_mutex_deinitialize);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_shared);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_producer);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_consumer);
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_output_console);
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_output_file);
 
     g_klog_state.p_semaphore_messages_empty = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_semaphore_t));
     g_klog_state.p_semaphore_messages_full  = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_semaphore_t));
@@ -292,15 +276,21 @@ void klog_deinitialize(
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_shared);
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_producer);
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_consumer);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_output_console);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_output_file);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_deinitialize);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_shared);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_producer);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_consumer);
-    g_klog_state.b_threads            = NULL;
-    g_klog_state.p_mutex_deinitialize = NULL;
-    g_klog_state.p_mutex_shared       = NULL;
-    g_klog_state.p_mutex_producer     = NULL;
-    g_klog_state.p_mutex_consumer     = NULL;
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_output_console);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_output_file);
+    g_klog_state.b_threads              = NULL;
+    g_klog_state.p_mutex_deinitialize   = NULL;
+    g_klog_state.p_mutex_shared         = NULL;
+    g_klog_state.p_mutex_producer       = NULL;
+    g_klog_state.p_mutex_consumer       = NULL;
+    g_klog_state.p_mutex_output_console = NULL;
+    g_klog_state.p_mutex_output_file    = NULL;
 
     klog_platform_semaphore_deinitialize(g_klog_state.p_semaphore_messages_empty);
     klog_platform_semaphore_deinitialize(g_klog_state.p_semaphore_messages_full);
@@ -357,14 +347,10 @@ void klog_deinitialize(
     g_klog_state.b_messages_formatted         = NULL;
     g_klog_state.b_messages_formatted_staging = NULL;
     g_klog_config.alloc.free_cb(g_klog_state.b_message_lengths);
-    g_klog_config.alloc.free_cb(g_klog_state.b_message_lengths_staging);
-    g_klog_state.b_message_lengths         = NULL;
-    g_klog_state.b_message_lengths_staging = NULL;
+    g_klog_state.b_message_lengths = NULL;
 
     g_klog_config.alloc.free_cb(g_klog_state.b_message_levels);
-    g_klog_config.alloc.free_cb(g_klog_state.b_message_levels_staging);
-    g_klog_state.b_message_levels         = NULL;
-    g_klog_state.b_message_levels_staging = NULL;
+    g_klog_state.b_message_levels = NULL;
 
     if (g_klog_state.s_filename) {
         g_klog_config.alloc.free_cb(g_klog_state.s_filename);
@@ -558,9 +544,10 @@ void klog_log(
         : (KlogString) { 0, NULL };
 
     /* Get the pointers to the prefix buffers and reset them in preparation for setting */
-    char* s_prefix_file    = g_klog_state.b_prefixes_file + (g_klog_state.message_element_producer_idx * g_klog_state.prefix_file_size);
+    char* s_prefix_file = g_klog_state.b_prefixes_file
+        + (g_klog_state.message_element_producer_idx * (g_klog_state.prefix_file_size + 1));
     char* s_prefix_console = g_klog_state.b_prefixes_console
-        + (g_klog_state.message_element_producer_idx * g_klog_state.prefix_console_size);
+        + (g_klog_state.message_element_producer_idx * (g_klog_state.prefix_console_size + 1));
     memset(s_prefix_file,    '\0', g_klog_state.prefix_file_size);
     memset(s_prefix_console, '\0', g_klog_state.prefix_console_size);
 

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -646,6 +646,12 @@ void klog_log(
         return;
     }
 
+    /**
+     * @brief We are still leveraging the consumer's function here because we need to guard against
+     *      the case where this klog_log function is being invoked from multiple threads without a
+     *      backing consumer. This will prevent any weirdness from happening if two threads are
+     *      both trying to produce logs at the same time
+     */
     klog_async_consume();
 #endif
 }

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -645,6 +645,7 @@ void klog_log(
     if (g_klog_config.async.number_backing_threads > 0) {
         return;
     }
+
     klog_async_consume();
 #endif
 }

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -144,7 +144,21 @@ void klog_initialize(
         true,
         g_klog_config.alloc.alloc_cb
     );
+    g_klog_state.b_prefixes_file_staging = klog_initialize_buffer(
+        g_klog_state.message_element_count,
+        g_klog_state.prefix_file_size,
+        '\0',
+        true,
+        g_klog_config.alloc.alloc_cb
+    );
     g_klog_state.b_prefixes_console = klog_initialize_buffer(
+        g_klog_state.message_element_count,
+        g_klog_state.prefix_console_size,
+        '\0',
+        true,
+        g_klog_config.alloc.alloc_cb
+    );
+    g_klog_state.b_prefixes_console_staging = klog_initialize_buffer(
         g_klog_state.message_element_count,
         g_klog_state.prefix_console_size,
         '\0',
@@ -174,15 +188,52 @@ void klog_initialize(
         false,
         g_klog_config.alloc.alloc_cb
     );
+    g_klog_state.b_messages_formatted_staging = klog_initialize_buffer(
+        g_klog_state.message_element_count,
+        g_klog_state.message_formatted_max_size, /* Each message slot is null terminated */
+        '\0',
+        false,
+        g_klog_config.alloc.alloc_cb
+    );
+    g_klog_state.b_message_lengths = g_klog_config.alloc.alloc_cb(
+        sizeof(*g_klog_state.b_message_lengths)
+        * g_klog_state.message_element_count
+    );
+    g_klog_state.b_message_lengths_staging = g_klog_config.alloc.alloc_cb(
+        sizeof(*g_klog_state.b_message_lengths_staging)
+        * g_klog_state.message_element_count
+    );
+    memset(
+        g_klog_state.b_message_lengths,
+        0,
+        sizeof(*g_klog_state.b_message_lengths)
+        * g_klog_state.message_element_count
+    );
+    memset(
+        g_klog_state.b_message_lengths_staging,
+        0,
+        sizeof(*g_klog_state.b_message_lengths_staging)
+        * g_klog_state.message_element_count
+    );
 
     g_klog_state.b_message_levels = g_klog_config.alloc.alloc_cb(
         sizeof(*g_klog_state.b_message_levels)
+        * g_klog_state.message_element_count
+    );
+    g_klog_state.b_message_levels_staging = g_klog_config.alloc.alloc_cb(
+        sizeof(*g_klog_state.b_message_levels_staging)
         * g_klog_state.message_element_count
     );
     memset(
         g_klog_state.b_message_levels,
         0,
         sizeof(*g_klog_state.b_message_levels)
+        * g_klog_state.message_element_count
+    );
+    memset(
+        g_klog_state.b_message_levels_staging,
+        0,
+        sizeof(*g_klog_state.b_message_levels_staging)
         * g_klog_state.message_element_count
     );
 
@@ -282,11 +333,15 @@ void klog_deinitialize(
 
     g_klog_state.prefix_file_size = 0;
     g_klog_config.alloc.free_cb(g_klog_state.b_prefixes_file);
-    g_klog_state.b_prefixes_file = NULL;
+    g_klog_config.alloc.free_cb(g_klog_state.b_prefixes_file_staging);
+    g_klog_state.b_prefixes_file         = NULL;
+    g_klog_state.b_prefixes_file_staging = NULL;
 
     g_klog_state.prefix_console_size = 0;
     g_klog_config.alloc.free_cb(g_klog_state.b_prefixes_console);
-    g_klog_state.b_prefixes_console = NULL;
+    g_klog_config.alloc.free_cb(g_klog_state.b_prefixes_console_staging);
+    g_klog_state.b_prefixes_console         = NULL;
+    g_klog_state.b_prefixes_console_staging = NULL;
 
     g_klog_state.prefix_time_size = 0;
     g_klog_config.alloc.free_cb(g_klog_state.b_prefixes_time);
@@ -298,10 +353,18 @@ void klog_deinitialize(
 
     g_klog_state.message_formatted_max_size = 0;
     g_klog_config.alloc.free_cb(g_klog_state.b_messages_formatted);
-    g_klog_state.b_messages_formatted = NULL;
+    g_klog_config.alloc.free_cb(g_klog_state.b_messages_formatted_staging);
+    g_klog_state.b_messages_formatted         = NULL;
+    g_klog_state.b_messages_formatted_staging = NULL;
+    g_klog_config.alloc.free_cb(g_klog_state.b_message_lengths);
+    g_klog_config.alloc.free_cb(g_klog_state.b_message_lengths_staging);
+    g_klog_state.b_message_lengths         = NULL;
+    g_klog_state.b_message_lengths_staging = NULL;
 
     g_klog_config.alloc.free_cb(g_klog_state.b_message_levels);
-    g_klog_state.b_message_levels = NULL;
+    g_klog_config.alloc.free_cb(g_klog_state.b_message_levels_staging);
+    g_klog_state.b_message_levels         = NULL;
+    g_klog_state.b_message_levels_staging = NULL;
 
     if (g_klog_state.s_filename) {
         g_klog_config.alloc.free_cb(g_klog_state.s_filename);
@@ -456,6 +519,8 @@ void klog_log(
     /* Create the input string with the arguments injected - including space for null termination */
     char* s_message_formatted = g_klog_state.b_messages_formatted
         + (g_klog_state.message_element_producer_idx * g_klog_state.message_formatted_max_size);
+    /* Clear the message buffer for the formatted message we just used */
+    memset(s_message_formatted, 0, g_klog_state.message_formatted_max_size);
     va_list p_args;
     va_start(p_args, s_format);
     const uint32_t actual_message_length = klog_format_input_message(

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -530,6 +530,8 @@ void klog_log(
         p_args
     );
     va_end(p_args);
+    /* Update the length buffer */
+    g_klog_state.b_message_lengths[g_klog_state.message_element_producer_idx] = actual_message_length;
 
     /* Get the information to create the message prefix */
     const uint32_t    thread_id         = (uint32_t)klog_platform_get_current_thread_id();

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -488,14 +488,43 @@ void klog_log(
         return;
     }
 
-    klog_platform_semaphore_wait(g_klog_state.p_semaphore_messages_empty);
-
-    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
-
     /* We are getting the time first, so it's closest to the actual point of invocation */
     char* s_prefix_time = g_klog_state.b_prefixes_time + (g_klog_state.message_element_producer_idx * g_klog_state.prefix_time_size);
     memset(s_prefix_time, '\0', g_klog_state.prefix_time_size);
     const KlogString packed_time = g_klog_config.format.use_timestamp ? klog_format_time(s_prefix_time) : (KlogString) { 0, NULL };
+
+    /* Get the information to create the message prefixes */
+    const uint32_t    thread_id         = (uint32_t)klog_platform_get_current_thread_id();
+    const uint32_t    logger_name_index = p_logger_handle->value * g_klog_config.format.logger_name_max_length;
+    const char* const s_logger_name     = &(g_klog_state.b_logger_names[logger_name_index]); /* Will eventually need to go behind a mutex for logger modifications */
+    const char* const s_level           = &(g_klog_state.b_level_strings[G_klog_level_string_length * requested_level]);
+    const char* const s_level_colored   = &(g_klog_state.b_level_strings_colored[G_klog_colored_level_string_length * requested_level]);
+
+    /* More message prefixe prep */
+    const uint32_t* const   p_thread_id            = g_klog_config.format.use_thread_id ? &thread_id : NULL;
+    const KlogString        packed_name            = { g_klog_config.format.logger_name_max_length, s_logger_name };
+    const KlogString        packed_level_color     = { G_klog_colored_level_string_length, s_level_colored };
+    const KlogString        packed_level_file      = { G_klog_level_string_length, s_level };
+    const KlogString* const p_packed_level_console = g_klog_config.console.use_color ? &packed_level_color : &packed_level_file;
+
+    /* Source location for the message prefix */
+    char* s_prefix_source_location = g_klog_state.b_prefixes_source_location
+        + (g_klog_state.message_element_producer_idx * g_klog_state.prefix_source_location_size);
+    const KlogString packed_source_location = (g_klog_config.format.source_location_filename_max_length && s_filename)
+        ? klog_format_source_location(
+                s_prefix_source_location,
+                g_klog_config.format.source_location_filename_max_length,
+                s_filename,
+                line_number
+            )
+        : (KlogString) { 0, NULL };
+
+    klog_platform_semaphore_wait(g_klog_state.p_semaphore_messages_empty);
+
+    klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
+
+    /* Update the level buffer */
+    g_klog_state.b_message_levels[g_klog_state.message_element_producer_idx] = requested_level;
 
     /* Create the input string with the arguments injected - including space for null termination */
     char* s_message_formatted = g_klog_state.b_messages_formatted
@@ -511,42 +540,14 @@ void klog_log(
         p_args
     );
     va_end(p_args);
+
     /* Update the length buffer */
     g_klog_state.b_message_lengths[g_klog_state.message_element_producer_idx] = actual_message_length;
 
-    /* Get the information to create the message prefix */
-    const uint32_t    thread_id         = (uint32_t)klog_platform_get_current_thread_id();
-    const uint32_t    logger_name_index = p_logger_handle->value * g_klog_config.format.logger_name_max_length;
-    const char* const s_logger_name     = &(g_klog_state.b_logger_names[logger_name_index]);
-    const char* const s_level           = &(g_klog_state.b_level_strings[G_klog_level_string_length * requested_level]);
-    const char* const s_level_colored   = &(g_klog_state.b_level_strings_colored[G_klog_colored_level_string_length * requested_level]);
-
-    const uint32_t* const   p_thread_id            = g_klog_config.format.use_thread_id ? &thread_id : NULL;
-    const KlogString        packed_name            = { g_klog_config.format.logger_name_max_length, s_logger_name };
-    const KlogString        packed_level_color     = { G_klog_colored_level_string_length, s_level_colored };
-    const KlogString        packed_level_file      = { G_klog_level_string_length, s_level };
-    const KlogString* const p_packed_level_console = g_klog_config.console.use_color ? &packed_level_color : &packed_level_file;
-
-    char* s_prefix_source_location = g_klog_state.b_prefixes_source_location
-        + (g_klog_state.message_element_producer_idx * g_klog_state.prefix_source_location_size);
-    const KlogString packed_source_location = (g_klog_config.format.source_location_filename_max_length && s_filename)
-        ? klog_format_source_location(
-                s_prefix_source_location,
-                g_klog_config.format.source_location_filename_max_length,
-                s_filename,
-                line_number
-            )
-        : (KlogString) { 0, NULL };
-
-    /* Get the pointers to the prefix buffers and reset them in preparation for setting */
+    /* Actually create the file prefix */
     char* s_prefix_file = g_klog_state.b_prefixes_file
         + (g_klog_state.message_element_producer_idx * (g_klog_state.prefix_file_size + 1));
-    char* s_prefix_console = g_klog_state.b_prefixes_console
-        + (g_klog_state.message_element_producer_idx * (g_klog_state.prefix_console_size + 1));
-    memset(s_prefix_file,    '\0', g_klog_state.prefix_file_size);
-    memset(s_prefix_console, '\0', g_klog_state.prefix_console_size);
-
-    /* Actually create the prefixes. We create one for the file and one for the console in case the console is using color */
+    memset(s_prefix_file, '\0', g_klog_state.prefix_file_size);
     const KlogString packed_prefix_file = klog_format_message_prefix(
         s_prefix_file,
         p_thread_id,
@@ -555,6 +556,11 @@ void klog_log(
         &packed_level_file,
         &packed_source_location
     );
+
+    /* Actually create the console prefix */
+    char* s_prefix_console = g_klog_state.b_prefixes_console
+        + (g_klog_state.message_element_producer_idx * (g_klog_state.prefix_console_size + 1));
+    memset(s_prefix_console, '\0', g_klog_state.prefix_console_size);
     const KlogString packed_prefix_console = klog_format_message_prefix(
         s_prefix_console,
         p_thread_id,
@@ -563,9 +569,6 @@ void klog_log(
         p_packed_level_console,
         &packed_source_location
     );
-
-    /* Update the level buffer */
-    g_klog_state.b_message_levels[g_klog_state.message_element_producer_idx] = requested_level;
 
     /* Update the producer's index into our ring buffer */
     g_klog_state.message_element_producer_idx = g_klog_state.message_element_producer_idx + 1;

--- a/src/klog/klog_async.c
+++ b/src/klog/klog_async.c
@@ -70,6 +70,7 @@ bool klog_async_consume(
 
     /* @todo Do we need an additional buffer denoting lengths, for speed up so we don't have to use strlen? */
     const uint32_t actual_message_length = strlen(s_message_formatted);
+    /* const uint32_t actual_message_length = g_klog_state.g_message_lengths[g_klog_state.message_element_consumer_idx]; */
 
     /* Get the console and file prefixes */
     char* s_prefix_file    = g_klog_state.b_prefixes_file + (g_klog_state.message_element_consumer_idx * g_klog_state.prefix_file_size);
@@ -95,10 +96,6 @@ bool klog_async_consume(
 
         i_starting_character = i_starting_character + submessage_length + 1;
     }
-
-    /* Clear the message buffer for the formatted message we just used */
-    /* @todo We shouldn't do this here - this should be done in the producer so we don't need to worry about staying sync-ed after outputting */
-    memset(s_message_formatted, 0, g_klog_state.message_formatted_max_size);
 
     /* Update the consumer's index into our ring buffer */
     g_klog_state.message_element_consumer_idx = g_klog_state.message_element_consumer_idx + 1;

--- a/src/klog/klog_async.c
+++ b/src/klog/klog_async.c
@@ -41,21 +41,19 @@ bool klog_async_consume(
 ) {
     klog_platform_semaphore_wait(g_klog_state.p_semaphore_messages_full);
 
+    klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
+    const bool should_deinit = !g_klog_state.is_initialized;
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
+
     klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
 
     if (g_klog_state.message_produced_total_count == g_klog_state.message_consumed_total_count) {
         /* We have logged everything we should have - up to this point. Should we stop?? */
-        klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
-
-        if (!g_klog_state.is_initialized) {
+        if (should_deinit) {
             /* We should stop */
-            klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
             klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
             return true;
         }
-
-        /* Let's keep going */
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
     }
 
     /* Copy everything from the producer's buffers to our staging buffers, let the producer know it can go again */
@@ -63,24 +61,30 @@ bool klog_async_consume(
     const uint32_t offset_file                  = (g_klog_state.prefix_file_size + 1) * message_element_consumer_idx;
     const uint32_t offset_console               = (g_klog_state.prefix_console_size + 1) * message_element_consumer_idx;
     const uint32_t offset_messages_formatted    = g_klog_state.message_formatted_max_size * message_element_consumer_idx;
-    /* Get the level and length from the shared buffers of corresponding to messages - no need for staging buffer for 1 word */
-    const enum KlogLevel requested_level       = g_klog_state.b_message_levels[message_element_consumer_idx];
-    const uint32_t       actual_message_length = g_klog_state.b_message_lengths[message_element_consumer_idx];
+    enum KlogLevel requested_level              = 0;
+    uint32_t       actual_message_length        = 0;
     {
+        /* These operations are done in the same order as in the producer, so we can have a higher degree of parellelism */
+        requested_level = g_klog_state.b_message_levels[message_element_consumer_idx];
+
+        memcpy(
+            g_klog_state.b_messages_formatted_staging + offset_messages_formatted,
+            g_klog_state.b_messages_formatted + offset_messages_formatted,
+            g_klog_state.message_formatted_max_size
+        );
+
+        actual_message_length = g_klog_state.b_message_lengths[message_element_consumer_idx];
+
         memcpy(
             g_klog_state.b_prefixes_file_staging + offset_file,
             g_klog_state.b_prefixes_file + offset_file,
             g_klog_state.prefix_file_size + 1
         );
+
         memcpy(
             g_klog_state.b_prefixes_console_staging + offset_console,
             g_klog_state.b_prefixes_console + offset_console,
             g_klog_state.prefix_console_size + 1
-        );
-        memcpy(
-            g_klog_state.b_messages_formatted_staging + offset_messages_formatted,
-            g_klog_state.b_messages_formatted + offset_messages_formatted,
-            g_klog_state.message_formatted_max_size
         );
 
         /* Update the consumer's index into our ring buffer */

--- a/src/klog/klog_async.c
+++ b/src/klog/klog_async.c
@@ -68,9 +68,7 @@ bool klog_async_consume(
     char* s_message_formatted = g_klog_state.b_messages_formatted
         + (g_klog_state.message_element_consumer_idx * g_klog_state.message_formatted_max_size);
 
-    /* @todo Do we need an additional buffer denoting lengths, for speed up so we don't have to use strlen? */
-    const uint32_t actual_message_length = strlen(s_message_formatted);
-    /* const uint32_t actual_message_length = g_klog_state.g_message_lengths[g_klog_state.message_element_consumer_idx]; */
+    const uint32_t actual_message_length = g_klog_state.b_message_lengths[g_klog_state.message_element_consumer_idx];
 
     /* Get the console and file prefixes */
     char* s_prefix_file    = g_klog_state.b_prefixes_file + (g_klog_state.message_element_consumer_idx * g_klog_state.prefix_file_size);

--- a/src/klog/klog_async.c
+++ b/src/klog/klog_async.c
@@ -46,7 +46,6 @@ bool klog_async_consume(
     klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
 
     klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
-
     /* @todo kjk 2026/08/01 I think we can make this stopping logic better */
     /* @todo Move these variable accesses behind a "stop" lock? */
     if (g_klog_state.message_produced_total_count == g_klog_state.message_consumed_total_count) {
@@ -57,7 +56,9 @@ bool klog_async_consume(
             return true;
         }
     }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
 
+    klog_platform_mutex_lock(g_klog_state.p_mutex_consumer);
     /* @todo This can move out of the shared block behind a consumer specific lock */
     /* Get our current consuming index and update the next consumer's index into the ring buffers */
     const uint32_t message_element_consumer_idx = g_klog_state.message_element_consumer_idx;
@@ -65,6 +66,7 @@ bool klog_async_consume(
     if (g_klog_state.message_element_consumer_idx >= g_klog_state.message_element_count) {
         g_klog_state.message_element_consumer_idx = 0;
     }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_consumer);
 
     /* Copy everything from the producer's buffers to our staging buffers, let the producer know it can go again */
     const uint32_t offset_file               = (g_klog_state.prefix_file_size + 1) * message_element_consumer_idx;
@@ -74,28 +76,40 @@ bool klog_async_consume(
     uint32_t       actual_message_length     = 0;
     {
         /* These operations are done in the same order as in the producer, so we can have a higher degree of parellelism */
-        requested_level = g_klog_state.b_message_levels[message_element_consumer_idx];
 
+        klog_platform_mutex_lock(g_klog_state.p_mutex_message_levels);
+        requested_level = g_klog_state.b_message_levels[message_element_consumer_idx];
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_message_levels);
+
+        klog_platform_mutex_lock(g_klog_state.p_mutex_messages_formatted);
         memcpy(
             g_klog_state.b_messages_formatted_staging + offset_messages_formatted,
             g_klog_state.b_messages_formatted + offset_messages_formatted,
             g_klog_state.message_formatted_max_size
         );
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_messages_formatted);
 
+        klog_platform_mutex_lock(g_klog_state.p_mutex_message_lengths);
         actual_message_length = g_klog_state.b_message_lengths[message_element_consumer_idx];
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_message_lengths);
 
+        klog_platform_mutex_lock(g_klog_state.p_mutex_prefixes_file);
         memcpy(
             g_klog_state.b_prefixes_file_staging + offset_file,
             g_klog_state.b_prefixes_file + offset_file,
             g_klog_state.prefix_file_size + 1
         );
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_prefixes_file);
 
+        klog_platform_mutex_lock(g_klog_state.p_mutex_prefixes_console);
         memcpy(
             g_klog_state.b_prefixes_console_staging + offset_console,
             g_klog_state.b_prefixes_console + offset_console,
             g_klog_state.prefix_console_size + 1
         );
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_prefixes_console);
 
+        klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
         /* @todo Can these things go behind the "stop" lock that the message_produced_total_count and message_consumed_total_count will go behind? */
         if (g_klog_state.message_unconsumed_count < 1) {
             kdprintf("klog_async_consume consumed too many messages\n");
@@ -103,8 +117,8 @@ bool klog_async_consume(
         }
         g_klog_state.message_consumed_total_count++;
         g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count - 1;
-
         klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
+
         klog_platform_semaphore_signal(g_klog_state.p_semaphore_messages_empty);
     }
 

--- a/src/klog/klog_async.c
+++ b/src/klog/klog_async.c
@@ -46,11 +46,6 @@ bool klog_async_consume(
     klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
 
     klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
-    /**
-     * The variables in here which are actually shared amongst producer and consumer:
-     *  - message_produced_total_count
-     *  - message_unconsumed_count
-     */
     if (g_klog_state.message_produced_total_count == g_klog_state.message_consumed_total_count) {
         /* We have logged everything we should have - up to this point. Should we stop?? */
         if (should_deinit) {

--- a/src/klog/klog_async.c
+++ b/src/klog/klog_async.c
@@ -39,8 +39,6 @@ void* klog_async_thread_body(
 bool klog_async_consume(
     void
 ) {
-    klog_platform_mutex_lock(g_klog_state.p_mutex_consumer);
-
     klog_platform_semaphore_wait(g_klog_state.p_semaphore_messages_full);
 
     klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
@@ -53,7 +51,6 @@ bool klog_async_consume(
             /* We should stop */
             klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
             klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
-            klog_platform_mutex_unlock(g_klog_state.p_mutex_consumer);
             return true;
         }
 
@@ -132,8 +129,6 @@ bool klog_async_consume(
 
         i_starting_character = i_starting_character + submessage_length + 1;
     }
-
-    klog_platform_mutex_unlock(g_klog_state.p_mutex_consumer);
 
     return false;
 }

--- a/src/klog/klog_async.c
+++ b/src/klog/klog_async.c
@@ -47,6 +47,8 @@ bool klog_async_consume(
 
     klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
 
+    /* @todo kjk 2026/08/01 I think we can make this stopping logic better */
+    /* @todo Move these variable accesses behind a "stop" lock? */
     if (g_klog_state.message_produced_total_count == g_klog_state.message_consumed_total_count) {
         /* We have logged everything we should have - up to this point. Should we stop?? */
         if (should_deinit) {
@@ -56,13 +58,20 @@ bool klog_async_consume(
         }
     }
 
-    /* Copy everything from the producer's buffers to our staging buffers, let the producer know it can go again */
+    /* @todo This can move out of the shared block behind a consumer specific lock */
+    /* Get our current consuming index and update the next consumer's index into the ring buffers */
     const uint32_t message_element_consumer_idx = g_klog_state.message_element_consumer_idx;
-    const uint32_t offset_file                  = (g_klog_state.prefix_file_size + 1) * message_element_consumer_idx;
-    const uint32_t offset_console               = (g_klog_state.prefix_console_size + 1) * message_element_consumer_idx;
-    const uint32_t offset_messages_formatted    = g_klog_state.message_formatted_max_size * message_element_consumer_idx;
-    enum KlogLevel requested_level              = 0;
-    uint32_t       actual_message_length        = 0;
+    g_klog_state.message_element_consumer_idx   = g_klog_state.message_element_consumer_idx + 1;
+    if (g_klog_state.message_element_consumer_idx >= g_klog_state.message_element_count) {
+        g_klog_state.message_element_consumer_idx = 0;
+    }
+
+    /* Copy everything from the producer's buffers to our staging buffers, let the producer know it can go again */
+    const uint32_t offset_file               = (g_klog_state.prefix_file_size + 1) * message_element_consumer_idx;
+    const uint32_t offset_console            = (g_klog_state.prefix_console_size + 1) * message_element_consumer_idx;
+    const uint32_t offset_messages_formatted = g_klog_state.message_formatted_max_size * message_element_consumer_idx;
+    enum KlogLevel requested_level           = 0;
+    uint32_t       actual_message_length     = 0;
     {
         /* These operations are done in the same order as in the producer, so we can have a higher degree of parellelism */
         requested_level = g_klog_state.b_message_levels[message_element_consumer_idx];
@@ -87,11 +96,7 @@ bool klog_async_consume(
             g_klog_state.prefix_console_size + 1
         );
 
-        /* Update the consumer's index into our ring buffer */
-        g_klog_state.message_element_consumer_idx = g_klog_state.message_element_consumer_idx + 1;
-        if (g_klog_state.message_element_consumer_idx >= g_klog_state.message_element_count) {
-            g_klog_state.message_element_consumer_idx = 0;
-        }
+        /* @todo Can these things go behind the "stop" lock that the message_produced_total_count and message_consumed_total_count will go behind? */
         if (g_klog_state.message_unconsumed_count < 1) {
             kdprintf("klog_async_consume consumed too many messages\n");
             exit(1);

--- a/src/klog/klog_async.c
+++ b/src/klog/klog_async.c
@@ -130,27 +130,18 @@ bool klog_async_consume(
     const KlogString packed_prefix_file    = { g_klog_state.prefix_file_size, s_prefix_file };
     const KlogString packed_prefix_console = { g_klog_state.prefix_console_size, s_prefix_console };
 
-    uint32_t i_starting_character = 0;
-    while (i_starting_character <= actual_message_length) {
-        const char* const p_newline         = strchr(s_message_formatted + i_starting_character, '\n');
-        const uint32_t    submessage_length = p_newline
-            ? p_newline - (s_message_formatted + i_starting_character)
-            : actual_message_length;
-
-        const KlogString packed_message = { submessage_length, s_message_formatted + i_starting_character };
-        if (requested_level <= g_klog_config.console.max_level) {
-            klog_platform_mutex_lock(g_klog_state.p_mutex_output_console);
-            klog_output_console(&packed_prefix_console, &packed_message);
-            klog_platform_mutex_unlock(g_klog_state.p_mutex_output_console);
-        }
-        if (g_klog_state.p_file && (requested_level <= g_klog_config.file.max_level)) {
-            klog_platform_mutex_lock(g_klog_state.p_mutex_output_file);
-            klog_output_file(g_klog_state.p_file, &packed_prefix_file, &packed_message);
-            klog_platform_mutex_unlock(g_klog_state.p_mutex_output_file);
-        }
-
-        i_starting_character = i_starting_character + submessage_length + 1;
-    }
+    klog_output(
+        actual_message_length,
+        s_message_formatted,
+        packed_prefix_console,
+        packed_prefix_file,
+        requested_level,
+        g_klog_config.console.max_level,
+        g_klog_config.file.max_level,
+        g_klog_state.p_file,
+        g_klog_state.p_mutex_output_console,
+        g_klog_state.p_mutex_output_file
+    );
 
     return false;
 }

--- a/src/klog/klog_async.c
+++ b/src/klog/klog_async.c
@@ -61,19 +61,53 @@ bool klog_async_consume(
         klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
     }
 
-    /* Get the level from the global buffer of levels corresponding to messages */
-    const enum KlogLevel requested_level = g_klog_state.b_message_levels[g_klog_state.message_element_consumer_idx];
+    /* Copy everything from the producer's buffers to our staging buffers, let the producer know it can go again */
+    const uint32_t message_element_consumer_idx = g_klog_state.message_element_consumer_idx;
+    const uint32_t offset_file                  = (g_klog_state.prefix_file_size + 1) * message_element_consumer_idx;
+    const uint32_t offset_console               = (g_klog_state.prefix_console_size + 1) * message_element_consumer_idx;
+    const uint32_t offset_messages_formatted    = g_klog_state.message_formatted_max_size * message_element_consumer_idx;
+    /* Get the level and length from the shared buffers of corresponding to messages - no need for staging buffer for 1 word */
+    const enum KlogLevel requested_level       = g_klog_state.b_message_levels[message_element_consumer_idx];
+    const uint32_t       actual_message_length = g_klog_state.b_message_lengths[message_element_consumer_idx];
+    {
+        memcpy(
+            g_klog_state.b_prefixes_file_staging + offset_file,
+            g_klog_state.b_prefixes_file + offset_file,
+            g_klog_state.prefix_file_size + 1
+        );
+        memcpy(
+            g_klog_state.b_prefixes_console_staging + offset_console,
+            g_klog_state.b_prefixes_console + offset_console,
+            g_klog_state.prefix_console_size + 1
+        );
+        memcpy(
+            g_klog_state.b_messages_formatted_staging + offset_messages_formatted,
+            g_klog_state.b_messages_formatted + offset_messages_formatted,
+            g_klog_state.message_formatted_max_size
+        );
+
+        /* Update the consumer's index into our ring buffer */
+        g_klog_state.message_element_consumer_idx = g_klog_state.message_element_consumer_idx + 1;
+        if (g_klog_state.message_element_consumer_idx >= g_klog_state.message_element_count) {
+            g_klog_state.message_element_consumer_idx = 0;
+        }
+        if (g_klog_state.message_unconsumed_count < 1) {
+            kdprintf("klog_async_consume consumed too many messages\n");
+            exit(1);
+        }
+        g_klog_state.message_consumed_total_count++;
+        g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count - 1;
+
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
+        klog_platform_semaphore_signal(g_klog_state.p_semaphore_messages_empty);
+    }
 
     /* Get the formatted message from the message buffer */
-    char* s_message_formatted = g_klog_state.b_messages_formatted
-        + (g_klog_state.message_element_consumer_idx * g_klog_state.message_formatted_max_size);
-
-    const uint32_t actual_message_length = g_klog_state.b_message_lengths[g_klog_state.message_element_consumer_idx];
+    char* s_message_formatted = g_klog_state.b_messages_formatted_staging + offset_messages_formatted;
 
     /* Get the console and file prefixes */
-    char* s_prefix_file    = g_klog_state.b_prefixes_file + (g_klog_state.message_element_consumer_idx * g_klog_state.prefix_file_size);
-    char* s_prefix_console = g_klog_state.b_prefixes_console
-        + (g_klog_state.message_element_consumer_idx * g_klog_state.prefix_console_size);
+    char*            s_prefix_file         = g_klog_state.b_prefixes_file_staging + offset_file;
+    char*            s_prefix_console      = g_klog_state.b_prefixes_console_staging + offset_console;
     const KlogString packed_prefix_file    = { g_klog_state.prefix_file_size, s_prefix_file };
     const KlogString packed_prefix_console = { g_klog_state.prefix_console_size, s_prefix_console };
 
@@ -86,31 +120,18 @@ bool klog_async_consume(
 
         const KlogString packed_message = { submessage_length, s_message_formatted + i_starting_character };
         if (requested_level <= g_klog_config.console.max_level) {
+            klog_platform_mutex_lock(g_klog_state.p_mutex_output_console);
             klog_output_console(&packed_prefix_console, &packed_message);
+            klog_platform_mutex_unlock(g_klog_state.p_mutex_output_console);
         }
         if (g_klog_state.p_file && (requested_level <= g_klog_config.file.max_level)) {
+            klog_platform_mutex_lock(g_klog_state.p_mutex_output_file);
             klog_output_file(g_klog_state.p_file, &packed_prefix_file, &packed_message);
+            klog_platform_mutex_unlock(g_klog_state.p_mutex_output_file);
         }
 
         i_starting_character = i_starting_character + submessage_length + 1;
     }
-
-    /* Update the consumer's index into our ring buffer */
-    g_klog_state.message_element_consumer_idx = g_klog_state.message_element_consumer_idx + 1;
-    if (g_klog_state.message_element_consumer_idx >= g_klog_state.message_element_count) {
-        g_klog_state.message_element_consumer_idx = 0;
-    }
-
-    if (g_klog_state.message_unconsumed_count < 1) {
-        kdprintf("klog_async_consume consumed too many messages\n");
-        exit(1);
-    }
-    g_klog_state.message_consumed_total_count++;
-    g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count - 1;
-
-    klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
-
-    klog_platform_semaphore_signal(g_klog_state.p_semaphore_messages_empty);
 
     klog_platform_mutex_unlock(g_klog_state.p_mutex_consumer);
 

--- a/src/klog/klog_async.c
+++ b/src/klog/klog_async.c
@@ -46,8 +46,11 @@ bool klog_async_consume(
     klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
 
     klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
-    /* @todo kjk 2026/08/01 I think we can make this stopping logic better */
-    /* @todo Move these variable accesses behind a "stop" lock? */
+    /**
+     * The variables in here which are actually shared amongst producer and consumer:
+     *  - message_produced_total_count
+     *  - message_unconsumed_count
+     */
     if (g_klog_state.message_produced_total_count == g_klog_state.message_consumed_total_count) {
         /* We have logged everything we should have - up to this point. Should we stop?? */
         if (should_deinit) {
@@ -56,6 +59,12 @@ bool klog_async_consume(
             return true;
         }
     }
+    if (g_klog_state.message_unconsumed_count < 1) {
+        kdprintf("klog_async_consume consumed too many messages\n");
+        exit(1);
+    }
+    g_klog_state.message_consumed_total_count++;
+    g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count - 1;
     klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
 
     klog_platform_mutex_lock(g_klog_state.p_mutex_consumer);
@@ -108,16 +117,6 @@ bool klog_async_consume(
             g_klog_state.prefix_console_size + 1
         );
         klog_platform_mutex_unlock(g_klog_state.p_mutex_prefixes_console);
-
-        klog_platform_mutex_lock(g_klog_state.p_mutex_shared);
-        /* @todo Can these things go behind the "stop" lock that the message_produced_total_count and message_consumed_total_count will go behind? */
-        if (g_klog_state.message_unconsumed_count < 1) {
-            kdprintf("klog_async_consume consumed too many messages\n");
-            exit(1);
-        }
-        g_klog_state.message_consumed_total_count++;
-        g_klog_state.message_unconsumed_count = g_klog_state.message_unconsumed_count - 1;
-        klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
 
         klog_platform_semaphore_signal(g_klog_state.p_semaphore_messages_empty);
     }

--- a/src/klog/klog_format.c
+++ b/src/klog/klog_format.c
@@ -54,6 +54,11 @@ char* klog_format_filename(
 
     free_cb((char*)s_sanitized_prefix);
 
+    if (full_filename == NULL) {
+        kdprintf("The resulting formatted filename is NULL for some reason\n");
+        exit(KLOG_EXIT_CODE);
+    }
+
     return full_filename;
 }
 

--- a/src/klog/klog_initialize.c
+++ b/src/klog/klog_initialize.c
@@ -203,7 +203,7 @@ FILE* klog_initialize_file(
     const char* const s_filename
 ) {
     if (s_filename == NULL) {
-        kdprintf("Not initializing output file\n");
+        kdprintf("Not initializing output file because filename is NULL\n");
         return NULL;
     }
 
@@ -212,7 +212,7 @@ FILE* klog_initialize_file(
         kdprintf("Failed to create log file at %s\n", s_filename);
         exit(KLOG_EXIT_CODE);
     }
-    kdprintf("Created output file pointer at %p\n", (void*)p_file);
+    kdprintf("Created output file pointer at %p, with name %s\n", (void*)p_file, s_filename);
 
     return p_file;
 }

--- a/src/klog/klog_output.c
+++ b/src/klog/klog_output.c
@@ -3,6 +3,47 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
+
+#include "klog/klog.h"
+
+#include "./klog_format.h"
+#include "./klog_platform.h"
+
+void klog_output(
+    const uint32_t         actual_message_length,
+    const char* const      s_message_formatted,
+    const KlogString       packed_prefix_console,
+    const KlogString       packed_prefix_file,
+    const uint8_t          level_requested,
+    const uint8_t          max_level_console,
+    const uint8_t          max_level_file,
+    FILE*                  p_file,
+    klog_platform_mutex_t* p_mutex_console,
+    klog_platform_mutex_t* p_mutex_file
+) {
+    uint32_t i_starting_character = 0;
+    while (i_starting_character <= actual_message_length) {
+        const char* const p_newline         = strchr(s_message_formatted + i_starting_character, '\n');
+        const uint32_t    submessage_length = p_newline
+            ? p_newline - (s_message_formatted + i_starting_character)
+            : actual_message_length;
+
+        const KlogString packed_message = { submessage_length, s_message_formatted + i_starting_character };
+        if (level_requested <= max_level_console) {
+            klog_platform_mutex_lock(p_mutex_console);
+            klog_output_console(&packed_prefix_console, &packed_message);
+            klog_platform_mutex_unlock(p_mutex_console);
+        }
+        if (p_file && (level_requested <= max_level_file)) {
+            klog_platform_mutex_lock(p_mutex_file);
+            klog_output_file(p_file, &packed_prefix_file, &packed_message);
+            klog_platform_mutex_unlock(p_mutex_file);
+        }
+
+        i_starting_character = i_starting_character + submessage_length + 1;
+    }
+}
 
 void klog_output_console(
     const KlogString* const p_prefix,

--- a/src/klog/klog_output.h
+++ b/src/klog/klog_output.h
@@ -6,6 +6,20 @@
 #include <stdio.h>
 
 #include "./klog_format.h"
+#include "./klog_platform.h"
+
+void klog_output(
+    uint32_t               actual_message_length,
+    const char*            s_message_formatted,
+    KlogString             packed_prefix_console,
+    KlogString             packed_prefix_file,
+    uint8_t                level_requested,
+    uint8_t                max_level_console,
+    uint8_t                max_level_file,
+    FILE*                  p_file,
+    klog_platform_mutex_t* p_mutex_console,
+    klog_platform_mutex_t* p_mutex_file
+);
 
 void klog_output_console(
     const KlogString* p_prefix,

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -60,11 +60,8 @@ extern struct KlogState {
     uint32_t  message_formatted_max_size;
     char*     b_messages_formatted; /* Need copy */
     char*     b_messages_formatted_staging;
-    uint32_t* b_message_lengths; /* Need copy */
-    uint32_t* b_message_lengths_staging;
-
-    uint32_t* b_message_levels; /* Need copy */
-    uint32_t* b_message_levels_staging;
+    uint32_t* b_message_lengths;
+    uint32_t* b_message_levels;
 
     char* s_filename;
     FILE* p_file;
@@ -76,6 +73,8 @@ extern struct KlogState {
     klog_platform_mutex_t*     p_mutex_shared;
     klog_platform_mutex_t*     p_mutex_producer;
     klog_platform_mutex_t*     p_mutex_consumer;
+    klog_platform_mutex_t*     p_mutex_output_console;
+    klog_platform_mutex_t*     p_mutex_output_file;
     klog_platform_semaphore_t* p_semaphore_messages_empty;
     klog_platform_semaphore_t* p_semaphore_messages_full;
 } g_klog_state;

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -47,18 +47,24 @@ extern struct KlogState {
     uint32_t message_consumed_total_count;
 
     uint32_t prefix_file_size;
-    char*    b_prefixes_file;
+    char*    b_prefixes_file; /* Need copy */
+    char*    b_prefixes_file_staging;
     uint32_t prefix_console_size;
-    char*    b_prefixes_console;
+    char*    b_prefixes_console; /* Need copy */
+    char*    b_prefixes_console_staging;
     uint32_t prefix_time_size;
     char*    b_prefixes_time;
     uint32_t prefix_source_location_size;
     char*    b_prefixes_source_location;
 
-    uint32_t message_formatted_max_size;
-    char*    b_messages_formatted;
+    uint32_t  message_formatted_max_size;
+    char*     b_messages_formatted; /* Need copy */
+    char*     b_messages_formatted_staging;
+    uint32_t* b_message_lengths; /* Need copy */
+    uint32_t* b_message_lengths_staging;
 
-    uint32_t* b_message_levels;
+    uint32_t* b_message_levels; /* Need copy */
+    uint32_t* b_message_levels_staging;
 
     char* s_filename;
     FILE* p_file;

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -47,10 +47,10 @@ extern struct KlogState {
     uint32_t message_consumed_total_count;
 
     uint32_t prefix_file_size;
-    char*    b_prefixes_file; /* Need copy */
+    char*    b_prefixes_file;
     char*    b_prefixes_file_staging;
     uint32_t prefix_console_size;
-    char*    b_prefixes_console; /* Need copy */
+    char*    b_prefixes_console;
     char*    b_prefixes_console_staging;
     uint32_t prefix_time_size;
     char*    b_prefixes_time;
@@ -58,7 +58,7 @@ extern struct KlogState {
     char*    b_prefixes_source_location;
 
     uint32_t  message_formatted_max_size;
-    char*     b_messages_formatted; /* Need copy */
+    char*     b_messages_formatted;
     char*     b_messages_formatted_staging;
     uint32_t* b_message_lengths;
     uint32_t* b_message_levels;

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -70,6 +70,11 @@ extern struct KlogState {
 
     klog_platform_thread_t*    b_threads;
     klog_platform_mutex_t*     p_mutex_deinitialize;
+    klog_platform_mutex_t*     p_mutex_message_levels;
+    klog_platform_mutex_t*     p_mutex_messages_formatted;
+    klog_platform_mutex_t*     p_mutex_message_lengths;
+    klog_platform_mutex_t*     p_mutex_prefixes_file;
+    klog_platform_mutex_t*     p_mutex_prefixes_console;
     klog_platform_mutex_t*     p_mutex_shared;
     klog_platform_mutex_t*     p_mutex_producer;
     klog_platform_mutex_t*     p_mutex_consumer;

--- a/src/klog/pt/pt-klog_sync_vs_async.c
+++ b/src/klog/pt/pt-klog_sync_vs_async.c
@@ -1,12 +1,16 @@
 #include <stdio.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #include "klog/klog.h"
 #include "../klog_platform.h"
+#include "../klog_state.h" /* So we can report the filename to the user and see why things look so strange (negative durations) */
 
 void run(
     const uint32_t num_threads
 ) {
+    klog_platform_sleep_usec(1000);
+
     const uint32_t num_logs = 50000;
 
     const KlogFormatInfo format_info = { 4, 20, 0, false, false };
@@ -16,6 +20,14 @@ void run(
     const KlogAsyncInfo* p_async_info = (num_threads > 0) ? &async_info : NULL;
 
     klog_initialize(1, format_info, p_async_info, NULL, &file_info, NULL);
+    if (g_klog_state.s_filename == NULL) {
+        printf("Output filename is NULL for iteration with %d backing threads!\n", num_threads);
+        exit(1);
+    }
+    if (g_klog_state.p_file == NULL) {
+        printf("Output file is NULL for iteration with %d backing threads!\n", num_threads);
+        exit(1);
+    }
 
     const KlogLoggerHandle* p_handle = klog_logger_create("name", 4);
     klog_logger_level_set(p_handle, KLOG_LEVEL_TRACE);
@@ -26,20 +38,46 @@ void run(
     }
     const timepoint_t end = klog_platform_get_current_timepoint();
 
-    klog_deinitialize();
-
-    const double start_seconds        = start.second + ((double)start.microsecond / 1000000.0);
-    const double end_seconds          = end.second + ((double)end.microsecond / 1000000.0);
+    const double start_seconds        = start.second_j2k + ((double)start.microsecond / 1000000.0);
+    const double end_seconds          = end.second_j2k + ((double)end.microsecond / 1000000.0);
     const double duration_sec         = end_seconds - start_seconds;
     const double duration_sec_per_log = duration_sec / num_logs;
 
     printf(
-        "%d logs with %d backing threads took %02.9f seconds (%.9f per log)\n",
+        "%d logs with %d backing threads took %02.9f seconds (%.9f per log) @ %s\n",
         num_logs,
         num_threads,
         duration_sec,
-        duration_sec_per_log
+        duration_sec_per_log,
+        g_klog_state.s_filename
     );
+
+    if ((duration_sec > 0) && (duration_sec_per_log > 0)) {
+        klog_deinitialize();
+        return;
+    }
+
+    /* For some reason we have a negative duraiton ... why??? */
+    printf("  - For some reason we have a negative duration\n");
+    printf("  - start point: %f\n", start_seconds);
+    printf("    - seconds: %d\n",   start.second_j2k);
+    printf("    - micros : %d\n",   start.microsecond);
+    printf("    - usec 2 : %f\n",   ((double)start.microsecond / 1000000.0));
+    printf("  - end   point: %f\n", end_seconds);
+    printf("    - seconds: %d\n",   end.second_j2k);
+    printf("    - micros : %d\n",   end.microsecond);
+    printf("    - usec 2 : %f\n",   ((double)end.microsecond / 1000000.0));
+    if (g_klog_state.s_filename == NULL) {
+        printf("  - output filename is NULL!\n");
+    } else {
+        printf("  - filename   : %s\n", g_klog_state.s_filename);
+    }
+    if (g_klog_state.p_file == NULL) {
+        printf("  - output file is NULL!\n");
+    }
+
+    klog_deinitialize();
+    exit(1);
 }
 
 int main(

--- a/src/klog/ut/ut-klog_alloc_callback_counts.c
+++ b/src/klog/ut/ut-klog_alloc_callback_counts.c
@@ -66,7 +66,7 @@ int check(
     );
 
     /* check post initialization values - not allocating threads here */
-    const uint32_t alloc_counter_init_expected = 20;
+    const uint32_t alloc_counter_init_expected = 26;
     if (g_alloc_counter != alloc_counter_init_expected) {
         printf("Alloc counter is %d after initialization when it should be %d\n", g_alloc_counter, alloc_counter_init_expected);
         return 1;
@@ -110,7 +110,7 @@ int check(
         printf("Alloc counter is %d after deinitializtion when it should be %d\n", g_alloc_counter, alloc_counter_deinit_expected);
         return 1;
     }
-    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 19;
+    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 25; /* @todo why is this different from the initial value (this is 1 less) */
     if (g_free_counter != free_counter_deinit_expected) {
         printf("Free counter is %d after deinitialization when it should be %d\n", g_free_counter, free_counter_deinit_expected);
         return 1;

--- a/src/klog/ut/ut-klog_alloc_callback_counts.c
+++ b/src/klog/ut/ut-klog_alloc_callback_counts.c
@@ -66,7 +66,7 @@ int check(
     );
 
     /* check post initialization values - not allocating threads here */
-    const uint32_t alloc_counter_init_expected = 26;
+    const uint32_t alloc_counter_init_expected = 31;
     if (g_alloc_counter != alloc_counter_init_expected) {
         printf("Alloc counter is %d after initialization when it should be %d\n", g_alloc_counter, alloc_counter_init_expected);
         return 1;
@@ -110,7 +110,7 @@ int check(
         printf("Alloc counter is %d after deinitializtion when it should be %d\n", g_alloc_counter, alloc_counter_deinit_expected);
         return 1;
     }
-    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 25; /* @todo why is this different from the initial value (this is 1 less) */
+    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 30; /* @todo why is this different from the initial value (this is 1 less) */
     if (g_free_counter != free_counter_deinit_expected) {
         printf("Free counter is %d after deinitialization when it should be %d\n", g_free_counter, free_counter_deinit_expected);
         return 1;

--- a/src/klog/ut/ut-klog_async_message_ordering.c
+++ b/src/klog/ut/ut-klog_async_message_ordering.c
@@ -21,7 +21,7 @@ char* populate_file(
 ) {
     /* Initialize klog with async and file information */
     KlogFormatInfo format_info = { 1, 4, 0, false, false };
-    KlogAsyncInfo  async_info  = { 5000, 4 };
+    KlogAsyncInfo  async_info  = { 5000, 1 };
     KlogFileInfo   file_info   = { KLOG_LEVEL_TRACE, "async_message_ordering" };
     klog_initialize(1, format_info, &async_info, NULL, &file_info, NULL);
 

--- a/src/klog/ut/ut-klog_async_message_ordering.c
+++ b/src/klog/ut/ut-klog_async_message_ordering.c
@@ -74,8 +74,8 @@ int check(
     }
     const uint32_t line_size          = g_prefix_length + g_message_digit_count + 1; /* 12 for prefix, 4 for the digits + 1 for newline */
     const uint32_t file_size_expected = line_size * g_num_messages;
-    if (file_size != file_size_expected) {
-        printf("Actual file size (%d) != expecte file size (%d)\n", file_size, file_size_expected);
+    if ((uint32_t)file_size != file_size_expected) {
+        printf("Actual file size (%d) != expected file size (%d)\n", file_size, file_size_expected);
         return 1;
     }
 

--- a/src/klog/ut/ut-klog_ring_buffer_usage.c
+++ b/src/klog/ut/ut-klog_ring_buffer_usage.c
@@ -53,11 +53,11 @@ int no_async_param(
         printf("Klog console prefix buffer is not initialized\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_file, empty_prefix_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file, empty_prefix_buffer, prefix_size - 1)) {
         printf("Klog file prefix buffer should be all null characters but it is not\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, empty_prefix_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, empty_prefix_buffer, prefix_size - 1)) {
         printf("Klog console prefix buffer should be all null characters but it is not\n");
         return 1;
     }
@@ -83,7 +83,7 @@ int no_async_param(
     }
 
     char* full_prefix_buffer_dum_info = "[dummy!] [info ] ";
-    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer_dum_info, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer_dum_info, prefix_size - 1)) {
         printf(
             "Klog file prefix buffer should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
             full_prefix_buffer_dum_info,
@@ -91,7 +91,7 @@ int no_async_param(
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer_dum_info, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer_dum_info, prefix_size - 1)) {
         printf(
             "Klog console prefix buffer should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
             full_prefix_buffer_dum_info,
@@ -155,11 +155,11 @@ int single_element(
         printf("Klog console prefix buffer is not initialized\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_file, empty_prefix_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file, empty_prefix_buffer, prefix_size - 1)) {
         printf("Klog file prefix buffer should be all null characters but it is not\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, empty_prefix_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, empty_prefix_buffer, prefix_size - 1)) {
         printf("Klog console prefix buffer should be all null characters but it is not\n");
         return 1;
     }
@@ -185,7 +185,7 @@ int single_element(
     }
 
     char* full_prefix_buffer_dum_info = "[dummy123] [info ] ";
-    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer_dum_info, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer_dum_info, prefix_size - 1)) {
         printf(
             "Klog file prefix buffer should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
             full_prefix_buffer_dum_info,
@@ -193,7 +193,7 @@ int single_element(
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer_dum_info, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer_dum_info, prefix_size - 1)) {
         printf(
             "Klog console prefix buffer should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
             full_prefix_buffer_dum_info,
@@ -320,11 +320,11 @@ int multiple_elements(
 
     char* empty_prefix_buffer = malloc(prefix_size);
     memset(empty_prefix_buffer, 0, prefix_size);
-    if (memcmp(g_klog_state.b_prefixes_file, empty_prefix_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file, empty_prefix_buffer, prefix_size - 1)) {
         printf("Klog file prefix buffer element 0 should be all null characters but it is not\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, empty_prefix_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, empty_prefix_buffer, prefix_size - 1)) {
         printf("Klog console prefix buffer element 0 should be all null characters but it is not\n");
         return 1;
     }
@@ -363,7 +363,8 @@ int multiple_elements(
     klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
 
     char* full_prefix_buffer_dum_info = "[dum] [info ] ";
-    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer_dum_info, prefix_size)) {
+
+    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer_dum_info, prefix_size - 1)) {
         printf(
             "Klog file prefix buffer element 0 should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
             full_prefix_buffer_dum_info,
@@ -371,7 +372,8 @@ int multiple_elements(
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer_dum_info, prefix_size)) {
+
+    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer_dum_info, prefix_size - 1)) {
         printf(
             "Klog console prefix buffer element 0 should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
             full_prefix_buffer_dum_info,
@@ -404,11 +406,11 @@ int multiple_elements(
         return 1;
     }
 
-    if (memcmp(g_klog_state.b_prefixes_file + prefix_size, empty_prefix_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file + prefix_size, empty_prefix_buffer, prefix_size - 1)) {
         printf("Klog file prefix buffer element 1 should be all null characters but it is not\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console + prefix_size, empty_prefix_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console + prefix_size, empty_prefix_buffer, prefix_size - 1)) {
         printf("Klog console prefix buffer element 1 should be all null characters but it is not\n");
         return 1;
     }
@@ -445,7 +447,7 @@ int multiple_elements(
     klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
 
     char* full_prefix_buffer_2 = "[two] [debug] ";
-    if (memcmp(g_klog_state.b_prefixes_file + prefix_size, full_prefix_buffer_2, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file + prefix_size, full_prefix_buffer_2, prefix_size - 1)) {
         printf(
             "Klog file prefix buffer element 1 should contain \"%s\" after logging at trace level, but instead it contains \"%s\"\n",
             full_prefix_buffer_2,
@@ -453,7 +455,7 @@ int multiple_elements(
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console + prefix_size, full_prefix_buffer_2, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console + prefix_size, full_prefix_buffer_2, prefix_size - 1)) {
         printf(
             "Klog console prefix buffer element 1 should contain \"%s\" after logging at trace level, but instead it contains \"%s\"\n",
             full_prefix_buffer_2,
@@ -464,11 +466,11 @@ int multiple_elements(
 
     /* Third logging statement */
 
-    if (memcmp(g_klog_state.b_prefixes_file + prefix_size * 2, empty_prefix_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file + prefix_size * 2, empty_prefix_buffer, prefix_size - 1)) {
         printf("Klog file prefix buffer element 2 should be all null characters but it is not\n");
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console + prefix_size * 2, empty_prefix_buffer, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console + prefix_size * 2, empty_prefix_buffer, prefix_size - 1)) {
         printf("Klog console prefix buffer element 2 should be all null characters but it is not\n");
         return 1;
     }
@@ -505,7 +507,7 @@ int multiple_elements(
     klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
 
     char* full_prefix_buffer_3 = "[3  ] [ERROR] ";
-    if (memcmp(g_klog_state.b_prefixes_file + prefix_size * 2, full_prefix_buffer_3, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file + prefix_size * 2, full_prefix_buffer_3, prefix_size - 1)) {
         printf(
             "Klog file prefix buffer element 2 should contain \"%s\" after logging at error level, but instead it contains \"%s\"\n",
             full_prefix_buffer_3,
@@ -513,7 +515,7 @@ int multiple_elements(
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console + prefix_size * 2, full_prefix_buffer_3, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console + prefix_size * 2, full_prefix_buffer_3, prefix_size - 1)) {
         printf(
             "Klog console prefix buffer element 2 should contain \"%s\" after logging at error level, but instead it contains \"%s\"\n",
             full_prefix_buffer_3,
@@ -524,7 +526,7 @@ int multiple_elements(
 
     /* Fourth logging statement */
 
-    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer_dum_info, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer_dum_info, prefix_size - 1)) {
         printf(
             "Klog file prefix buffer element 0 should contain \"%s\" before logging after overflow at info level, but instead it contains \"%s\"\n",
             full_prefix_buffer_dum_info,
@@ -532,7 +534,7 @@ int multiple_elements(
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer_dum_info, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer_dum_info, prefix_size - 1)) {
         printf(
             "Klog console prefix buffer element 0 should contain \"%s\" before logging after overflow at info level, but instead it contains \"%s\"\n",
             full_prefix_buffer_dum_info,
@@ -570,7 +572,7 @@ int multiple_elements(
     klog_platform_mutex_unlock(g_klog_state.p_mutex_shared);
 
     char* full_prefix_buffer_dum_fatal = "[dum] [FATAL] ";
-    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer_dum_fatal, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_file, full_prefix_buffer_dum_fatal, prefix_size - 1)) {
         printf(
             "Klog file prefix buffer element 0 should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
             full_prefix_buffer_dum_fatal,
@@ -578,7 +580,7 @@ int multiple_elements(
         );
         return 1;
     }
-    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer_dum_fatal, prefix_size)) {
+    if (memcmp(g_klog_state.b_prefixes_console, full_prefix_buffer_dum_fatal, prefix_size - 1)) {
         printf(
             "Klog console prefix buffer element 0 should contain \"%s\" after logging at info level, but instead it contains \"%s\"\n",
             full_prefix_buffer_dum_fatal,

--- a/src/klog/ut/ut-klog_ring_buffer_usage.c
+++ b/src/klog/ut/ut-klog_ring_buffer_usage.c
@@ -245,13 +245,13 @@ int multiple_elements(
         return 1;
     }
 
-    const uint32_t prefix_size = klog_format_prefix_length_get(false, false, logger_name_length, false, 0);
-    if (g_klog_state.prefix_file_size != prefix_size) {
-        printf("Klog file prefix size should be %d, but actually is %d\n", prefix_size, g_klog_state.prefix_console_size);
+    const uint32_t prefix_size = klog_format_prefix_length_get(false, false, logger_name_length, false, 0) + 1;
+    if (g_klog_state.prefix_file_size != prefix_size - 1) {
+        printf("Klog file prefix size should be %d, but actually is %d\n", prefix_size - 1, g_klog_state.prefix_console_size);
         return 1;
     }
-    if (g_klog_state.prefix_console_size != prefix_size) {
-        printf("Klog console prefix size should be %d, but actually is %d\n", prefix_size, g_klog_state.prefix_console_size);
+    if (g_klog_state.prefix_console_size != prefix_size - 1) {
+        printf("Klog console prefix size should be %d, but actually is %d\n", prefix_size - 1, g_klog_state.prefix_console_size);
         return 1;
     }
 


### PR DESCRIPTION
# v0.0.18 Async Performance Improvements

<!--
Include updated version, and use imperative mood.
Ex:

v1.2.3 rename boop to beep
-->

---

## Description

<!--
What does this change do?

- Describe the previous behavior and why it was bad.
- Describe the updated behavior and why it is good.
-->

This change improves the performance of the asynchronous logging capabilities.

### Implementation Details

<!--
What changes were made in order to get the desired, updated behavior?

- Give details that will help reviewers understand what is going on.
-->

Effectively we got rid of the large shared block, in favor of many smaller mutex guarded blocks, in order to improve synchronization. We also introduced a "staging" buffer which the consumer copies into, to allow the producer to continue immediately after submitting a message to the main buffer without having to wait for console and file IO to complete before it can modify the buffer again. We also moved as much logic out of the shared blocks as possible and updated the order in which resources are accessed in the producer/consumer to match the other.

---

## Motivation

<!--
Why is this change needed?

- What problem does it solve?
- Why is this the correct fix? Why not alternative approaches?
-->

Prior to these changes, non-asynchronous logging was performing faster than synchronous logging. This defeats the whole purpose of synchronous logging. We don't want to block the use on IO operations, but if the async mode is blocking more than the non-async mode, then they're opting into worse blocking instead of improved blocking.

See the `Testing` section for more information.

### Related Issues

<!--
Which issues does this close? Ex:

- closes #1
- closes #42
-->

- closes #47 

Test script issues addressed:
- closes #45 
- closes #46 
- closes #51 
- closes #52 

---

## Testing

<!--
How was this validated?

- Were new tests added? If so, which ones?
- Which currently in place tests are relevant?
- Include logs, traces, or minimal repro steps if applicable.
-->
#### Prior Performance
These results illustrate that the fastest case is the non-async case, and that when operating in async mode debug builds are faster than release builds.

Performance (`debug`) prior to changes:
```
(base) keegan@jade ~/Development/gneiss/.build_debug ( kjk/async_improvements) >>> ./bin/pt/pt-klog_sync_vs_async 
50000 logs with 0 backing threads took 0.162284000 seconds (0.000003246 per log)
50000 logs with 1 backing threads took 0.243042000 seconds (0.000004861 per log)
50000 logs with 2 backing threads took 0.273481000 seconds (0.000005470 per log)
50000 logs with 3 backing threads took 0.346655000 seconds (0.000006933 per log)
50000 logs with 4 backing threads took 0.356307000 seconds (0.000007126 per log)
```

Performance (`release`) prior to changes:
```
(base) keegan@jade ~/Development/gneiss/.build_release ( kjk/async_improvements) >>> ./bin/pt/pt-klog_sync_vs_async 
50000 logs with 0 backing threads took 0.146131000 seconds (0.000002923 per log)
50000 logs with 1 backing threads took 0.298748000 seconds (0.000005975 per log)
50000 logs with 2 backing threads took 0.371532000 seconds (0.000007431 per log)
50000 logs with 3 backing threads took 0.405702000 seconds (0.000008114 per log)
50000 logs with 4 backing threads took 0.613049000 seconds (0.000012261 per log)
```

#### Updated Performance
These results showcase that we get a large performance boost while using 1 backing thread. Using 2 backing threads is on average as fast as no asynchronous logging, and performance decreases with more than 2 backing threads.

Performance (`debug`) after changes:
```
(base) keegan@jade ~/Development/gneiss/.build_debug ( kjk/async_improvements) >>> ./bin/pt/pt-klog_sync_vs_async 
50000 logs with 0 backing threads took 0.172318935 seconds (0.000003446 per log) @ klog_sync_vs_async_20260802_123920_0156.log
50000 logs with 1 backing threads took 0.143235922 seconds (0.000002865 per log) @ klog_sync_vs_async_20260802_123920_0330.log
50000 logs with 2 backing threads took 0.172424078 seconds (0.000003448 per log) @ klog_sync_vs_async_20260802_123920_0475.log
50000 logs with 3 backing threads took 0.213536978 seconds (0.000004271 per log) @ klog_sync_vs_async_20260802_123920_0649.log
50000 logs with 4 backing threads took 0.254245043 seconds (0.000005085 per log) @ klog_sync_vs_async_20260802_123920_0863.log
```

Performance (`release`) after changes:
```
(base) keegan@jade ~/Development/gneiss/.build_release ( kjk/async_improvements) >>> ./bin/pt/pt-klog_sync_vs_async 
50000 logs with 0 backing threads took 0.171756029 seconds (0.000003435 per log) @ klog_sync_vs_async_20260803_191815_0745.log
50000 logs with 1 backing threads took 0.138998032 seconds (0.000002780 per log) @ klog_sync_vs_async_20260803_191815_0918.log
50000 logs with 2 backing threads took 0.171505928 seconds (0.000003430 per log) @ klog_sync_vs_async_20260803_191816_0059.log
50000 logs with 3 backing threads took 0.188069105 seconds (0.000003761 per log) @ klog_sync_vs_async_20260803_191816_0232.log
50000 logs with 4 backing threads took 0.189288855 seconds (0.000003786 per log) @ klog_sync_vs_async_20260803_191816_0421.log
```

---

## Checklist

- [x] Adherance to style guide (naming and formatting)
- [x] All tests pass
- [x] New tests added where appropriate
- [x] Documentation updated (everything exposed in headers really)
- [x] Concurrency implications considered
- [x] Self review performed
- [x] Version incremented if appropriate

---
