### PR TITLE
v0.0.19 Logger Creation/Modification Concurrency Safety

### DIFF
--- a/cmake/KlogVersion.cmake
+++ b/cmake/KlogVersion.cmake
@@ -22,4 +22,5 @@ endfunction()
 # set_klog_versions(0 0 15) # Don't allocate when formatting logger names
 # set_klog_versions(0 0 16) # Examples!
 # set_klog_versions(0 0 17) # Async logging with dedicated threads
-set_klog_versions(0 0 18) # Async logging improvements
+# set_klog_versions(0 0 18) # Async logging improvements
+set_klog_versions(0 0 19) # Non-logging async safety

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -52,7 +52,7 @@ if [ $should_pre_print -eq 0 ]; then
     P_EP="${NORMAL}passed (should pass)${NORMAL}"
     ME_EP="${FGYELLOW}MEMERR (should pass)${NORMAL}"
     F_EP="${FGRED}FAILED (should pass)${NORMAL}"
-SF_EP="${FGRED}SEGFLT (should pass)${NORMAL}"
+    SF_EP="${FGRED}SEGFLT (should pass)${NORMAL}"
 fi
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -101,7 +101,7 @@ run_test_update_failed_commands () {
       fi
     fi
 
-    { $command_to_run; } > /dev/null 2>&1
+    { $command_to_run; } > /dev/null 2>&1 # The curly braces basically allow us to silence any output fro core dumps
     local status=$?
 
     local did_expected=1

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -40,9 +40,10 @@ done
 P_EF="${FGRED}PASSED      (should fail)${NORMAL}"
 ME_EF="${FGYELLOW}MEMERR      (should fail)${NORMAL}"
 F_EF="${NORMAL}failed      (should fail)${NORMAL}"
-P_EP="${NORMAL}passed      (should pass)${NORMAL}"
+P_EP="${NORMAL} passed      (should pass)${NORMAL}"
 ME_EP="${FGYELLOW}MEMERR      (should pass)${NORMAL}"
 F_EP="${FGRED}FAILED      (should pass)${NORMAL}"
+SF_EP="${FGRED}SEGFLT      (should pass)${NORMAL}"
 
 if [ $should_pre_print -eq 0 ]; then
     P_EF="${FGRED}PASSED (should fail)${NORMAL}"
@@ -51,6 +52,7 @@ if [ $should_pre_print -eq 0 ]; then
     P_EP="${NORMAL}passed (should pass)${NORMAL}"
     ME_EP="${FGYELLOW}MEMERR (should pass)${NORMAL}"
     F_EP="${FGRED}FAILED (should pass)${NORMAL}"
+SF_EP="${FGRED}SEGFLT (should pass)${NORMAL}"
 fi
 
 # -------------------------------------------------------------------------------------------------------------------- #
@@ -99,7 +101,7 @@ run_test_update_failed_commands () {
       fi
     fi
 
-    $command_to_run > /dev/null 2>&1
+    { $command_to_run; } > /dev/null 2>&1
     local status=$?
 
     local did_expected=1
@@ -109,18 +111,24 @@ run_test_update_failed_commands () {
             result_message=$P_EF
             failed_commands+=( "$command_to_run" )
             did_expected=0
-        elif [ "$status" -eq 54 ]; then
+        elif [ "$status" -eq 54 ]; then # This is our custom valgrind exit code - so map it to memerr
             result_message=$ME_EF
             failed_commands+=( "$command_to_run" )
             did_expected=0
+        elif [ "$status" -eq 139 ]; then # @todo Handle segfaults differently than normal failures
+            result_message=$F_EF
         else
             result_message=$F_EF
         fi
     else # Else (we should have succeeded)
         if [ "$status" -eq 0 ]; then
             result_message=$P_EP
-        elif [ "$status" -eq 54 ]; then
+        elif [ "$status" -eq 54 ]; then # This is our custom valgrind exit code - so map it to memerr
             result_message=$ME_EP
+            failed_commands+=( "$command_to_run" )
+            did_expected=0
+        elif [ "$status" -eq 139 ]; then # This is the seg fault code - so map it to segfault
+            result_message=$SF_EP
             failed_commands+=( "$command_to_run" )
             did_expected=0
         else

--- a/src/klog/ft/ft-klog_fail_uninitialized.c
+++ b/src/klog/ft/ft-klog_fail_uninitialized.c
@@ -10,7 +10,9 @@ int main(
     void
 ) {
     /* Fail because klog is uninitialized */
+    printf("Attempting to create logger without initializing klog\n");
     const KlogLoggerHandle* handle_1 = klog_logger_create("MyLogger", 8);
+    printf("Attempting to create logger without initializing klog - done\n");
     klog(handle_1, KLOG_LEVEL_INFO, "This should not appear");
     klog_logger_level_set(handle_1, KLOG_LEVEL_DEBUG);
     klog(handle_1, KLOG_LEVEL_TRACE, "This should also not appear");

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -266,7 +266,7 @@ void klog_deinitialize(
 #else
     klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
     if (!g_klog_state.is_initialized) {
-        kdprintf("Trying to de-initialize klog, when it is not yet initialized\n");
+        kdprintf("Trying to de-initialize klog, when it is not initialized\n");
         exit(KLOG_EXIT_CODE);
     }
 
@@ -501,7 +501,7 @@ void klog_log(
 #else
     klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
     if (!g_klog_state.is_initialized) {
-        kdprintf("Trying to create klog logger, but klog is not initialized\n");
+        kdprintf("Trying to log, but klog is not initialized\n");
         exit(KLOG_EXIT_CODE);
     }
     klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);

--- a/src/klog/klog.c
+++ b/src/klog/klog.c
@@ -220,18 +220,20 @@ void klog_initialize(
     g_klog_state.s_filename = klog_format_filename(p_klog_file_info, g_klog_config.alloc.alloc_cb, g_klog_config.alloc.free_cb);
     g_klog_state.p_file     = klog_initialize_file(g_klog_state.s_filename);
 
-    g_klog_state.p_mutex_deinitialize       = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_message_levels     = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_messages_formatted = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_message_lengths    = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_prefixes_file      = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_prefixes_console   = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_shared             = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_producer           = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_consumer           = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_output_console     = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
-    g_klog_state.p_mutex_output_file        = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_deinitialize        = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_logger_modification = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_message_levels      = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_messages_formatted  = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_message_lengths     = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_prefixes_file       = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_prefixes_console    = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_shared              = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_producer            = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_consumer            = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_output_console      = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
+    g_klog_state.p_mutex_output_file         = g_klog_config.alloc.alloc_cb(sizeof(klog_platform_mutex_t));
     klog_platform_mutex_initialize(g_klog_state.p_mutex_deinitialize);
+    klog_platform_mutex_initialize(g_klog_state.p_mutex_logger_modification);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_message_levels);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_messages_formatted);
     klog_platform_mutex_initialize(g_klog_state.p_mutex_message_lengths);
@@ -283,6 +285,7 @@ void klog_deinitialize(
         g_klog_config.alloc.free_cb(g_klog_state.b_threads);
     }
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_deinitialize);
+    klog_platform_mutex_deinitialize(g_klog_state.p_mutex_logger_modification);
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_message_levels);
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_messages_formatted);
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_message_lengths);
@@ -294,6 +297,7 @@ void klog_deinitialize(
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_output_console);
     klog_platform_mutex_deinitialize(g_klog_state.p_mutex_output_file);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_deinitialize);
+    g_klog_config.alloc.free_cb(g_klog_state.p_mutex_logger_modification);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_message_levels);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_messages_formatted);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_message_lengths);
@@ -304,18 +308,19 @@ void klog_deinitialize(
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_consumer);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_output_console);
     g_klog_config.alloc.free_cb(g_klog_state.p_mutex_output_file);
-    g_klog_state.b_threads                  = NULL;
-    g_klog_state.p_mutex_deinitialize       = NULL;
-    g_klog_state.p_mutex_message_levels     = NULL;
-    g_klog_state.p_mutex_messages_formatted = NULL;
-    g_klog_state.p_mutex_message_lengths    = NULL;
-    g_klog_state.p_mutex_prefixes_file      = NULL;
-    g_klog_state.p_mutex_prefixes_console   = NULL;
-    g_klog_state.p_mutex_shared             = NULL;
-    g_klog_state.p_mutex_producer           = NULL;
-    g_klog_state.p_mutex_consumer           = NULL;
-    g_klog_state.p_mutex_output_console     = NULL;
-    g_klog_state.p_mutex_output_file        = NULL;
+    g_klog_state.b_threads                   = NULL;
+    g_klog_state.p_mutex_deinitialize        = NULL;
+    g_klog_state.p_mutex_logger_modification = NULL;
+    g_klog_state.p_mutex_message_levels      = NULL;
+    g_klog_state.p_mutex_messages_formatted  = NULL;
+    g_klog_state.p_mutex_message_lengths     = NULL;
+    g_klog_state.p_mutex_prefixes_file       = NULL;
+    g_klog_state.p_mutex_prefixes_console    = NULL;
+    g_klog_state.p_mutex_shared              = NULL;
+    g_klog_state.p_mutex_producer            = NULL;
+    g_klog_state.p_mutex_consumer            = NULL;
+    g_klog_state.p_mutex_output_console      = NULL;
+    g_klog_state.p_mutex_output_file         = NULL;
 
     klog_platform_semaphore_deinitialize(g_klog_state.p_semaphore_messages_empty);
     klog_platform_semaphore_deinitialize(g_klog_state.p_semaphore_messages_full);
@@ -399,10 +404,14 @@ const KlogLoggerHandle* klog_logger_create(
     (void)logger_name;
     return NULL;
 #else
+    klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
     if (!g_klog_state.is_initialized) {
         kdprintf("Trying to create klog logger, but klog is not initialized\n");
         exit(KLOG_EXIT_CODE);
     }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
+
+    klog_platform_mutex_lock(g_klog_state.p_mutex_logger_modification);
 
     if (g_klog_state.number_loggers_created >= g_klog_state.number_loggers_max) {
         kdprintf("Trying to create klog logger, but klog only allows %d loggers\n", g_klog_state.number_loggers_max);
@@ -432,6 +441,8 @@ const KlogLoggerHandle* klog_logger_create(
 
     g_klog_state.number_loggers_created++;
 
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_logger_modification);
+
     return p_logger_handle;
 #endif
 }
@@ -444,10 +455,14 @@ void klog_logger_level_set(
     (void)p_logger_handle;
     (void)updated_level;
 #else
+    klog_platform_mutex_lock(g_klog_state.p_mutex_deinitialize);
     if (!g_klog_state.is_initialized) {
         kdprintf("Trying to create klog logger, but klog is not initialized\n");
         exit(KLOG_EXIT_CODE);
     }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
+
+    klog_platform_mutex_lock(g_klog_state.p_mutex_logger_modification);
 
     if (p_logger_handle->value >= g_klog_state.number_loggers_created) {
         kdprintf(
@@ -464,6 +479,8 @@ void klog_logger_level_set(
     }
 
     g_klog_state.a_logger_levels[p_logger_handle->value] = updated_level;
+
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_logger_modification);
 #endif
 }
 
@@ -489,10 +506,12 @@ void klog_log(
     }
     klog_platform_mutex_unlock(g_klog_state.p_mutex_deinitialize);
 
+    klog_platform_mutex_lock(g_klog_state.p_mutex_logger_modification);
     if (p_logger_handle->value >= g_klog_state.number_loggers_created) {
         kdprintf("Trying to log with logger %d, when only %d loggers exist\n", p_logger_handle->value, g_klog_state.number_loggers_created);
         exit(KLOG_EXIT_CODE);
     }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_logger_modification);
 
     if (requested_level > KLOG_LEVEL_TRACE) {
         kdprintf("Trying to log with level (%d) greater than trace (%d)\n", requested_level, KLOG_LEVEL_TRACE);
@@ -503,15 +522,19 @@ void klog_log(
         kdprintf("Trying to log with the level set to OFF\n");
         return;
     }
+
     if ((requested_level > g_klog_config.console.max_level) && (requested_level > g_klog_config.file.max_level)) {
         kdprintf("Trying to log with a level that neither console nor file accept\n");
         return;
     }
 
+    klog_platform_mutex_lock(g_klog_state.p_mutex_logger_modification);
     if (requested_level > g_klog_state.a_logger_levels[p_logger_handle->value]) {
         kdprintf("Trying to log with a level more verbose than the requested logger allows\n");
+        klog_platform_mutex_unlock(g_klog_state.p_mutex_logger_modification);
         return;
     }
+    klog_platform_mutex_unlock(g_klog_state.p_mutex_logger_modification);
 
     klog_platform_semaphore_wait(g_klog_state.p_semaphore_messages_empty);
 
@@ -548,9 +571,10 @@ void klog_log(
     const KlogString packed_time = g_klog_config.format.use_timestamp ? klog_format_time(s_prefix_time) : (KlogString) { 0, NULL };
 
     /* Get the information to create the message prefixes */
+    /* b_logger_names doesn't need to be behind a mutex because it will never get updated after creation */
     const uint32_t    thread_id         = (uint32_t)klog_platform_get_current_thread_id();
     const uint32_t    logger_name_index = p_logger_handle->value * g_klog_config.format.logger_name_max_length;
-    const char* const s_logger_name     = &(g_klog_state.b_logger_names[logger_name_index]); /* Will eventually need to go behind a mutex for logger modifications */
+    const char* const s_logger_name     = &(g_klog_state.b_logger_names[logger_name_index]);
     const char* const s_level           = &(g_klog_state.b_level_strings[G_klog_level_string_length * requested_level]);
     const char* const s_level_colored   = &(g_klog_state.b_level_strings_colored[G_klog_colored_level_string_length * requested_level]);
 

--- a/src/klog/klog_state.h
+++ b/src/klog/klog_state.h
@@ -70,6 +70,7 @@ extern struct KlogState {
 
     klog_platform_thread_t*    b_threads;
     klog_platform_mutex_t*     p_mutex_deinitialize;
+    klog_platform_mutex_t*     p_mutex_logger_modification;
     klog_platform_mutex_t*     p_mutex_message_levels;
     klog_platform_mutex_t*     p_mutex_messages_formatted;
     klog_platform_mutex_t*     p_mutex_message_lengths;

--- a/src/klog/ut/ut-klog_alloc_callback_counts.c
+++ b/src/klog/ut/ut-klog_alloc_callback_counts.c
@@ -66,7 +66,7 @@ int check(
     );
 
     /* check post initialization values - not allocating threads here */
-    const uint32_t alloc_counter_init_expected = 31;
+    const uint32_t alloc_counter_init_expected = 32;
     if (g_alloc_counter != alloc_counter_init_expected) {
         printf("Alloc counter is %d after initialization when it should be %d\n", g_alloc_counter, alloc_counter_init_expected);
         return 1;
@@ -110,7 +110,7 @@ int check(
         printf("Alloc counter is %d after deinitializtion when it should be %d\n", g_alloc_counter, alloc_counter_deinit_expected);
         return 1;
     }
-    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 30; /* @todo why is this different from the initial value (this is 1 less) */
+    const uint32_t free_counter_deinit_expected = free_counter_created_expected + 31; /* @todo why is this different from the initial value (this is 1 less) */
     if (g_free_counter != free_counter_deinit_expected) {
         printf("Free counter is %d after deinitialization when it should be %d\n", g_free_counter, free_counter_deinit_expected);
         return 1;


### PR DESCRIPTION
# v0.0.19 Logger Creation/Modification Concurrency Safety

<!--
Include updated version, and use imperative mood.
Ex:

v1.2.3 rename boop to beep
-->

---

## Description

<!--
What does this change do?

- Describe the previous behavior and why it was bad.
- Describe the updated behavior and why it is good.
-->

This change locks all modifications to logger's levels and name buffers behind mutexes, to prevent any concurrency issues which may have occurred.

### Implementation Details

<!--
What changes were made in order to get the desired, updated behavior?

- Give details that will help reviewers understand what is going on.
-->

- create a new mutex
- gate the logger creation and logger level setting behind this mutex
- gate the logger number retreival (when logging) behind this mutex
- gate the logger current level retreival (when logging) behind this mutex

---

## Motivation

<!--
Why is this change needed?

- What problem does it solve?
- Why is this the correct fix? Why not alternative approaches?
-->

This was necessary because, prior to these changes, there was the possibility that two threads could be attempting to create loggers and update loggers levels at the same time, causing resource contention issues.

### Related Issues

<!--
Which issues does this close? Ex:

- closes #1
- closes #42
-->

- closes #49 

---

## Testing

<!--
How was this validated?

- Were new tests added? If so, which ones?
- Which currently in place tests are relevant?
- Include logs, traces, or minimal repro steps if applicable.
-->

- all tests pass

---

## Checklist

- [x] Adherance to style guide (naming and formatting)
- [x] All tests pass
- [ ] New tests added where appropriate
- [x] Documentation updated (everything exposed in headers really)
- [x] Concurrency implications considered
- [x] Self review performed
- [x] Version incremented if appropriate

---
